### PR TITLE
Change tracking policy

### DIFF
--- a/src/Entity/Traits/UsesPHPMetaDataTrait.php
+++ b/src/Entity/Traits/UsesPHPMetaDataTrait.php
@@ -68,6 +68,7 @@ trait UsesPHPMetaDataTrait
             static::$reflectionClass = $metadata->getReflectionClass();
             static::loadPropertyDoctrineMetaData($builder);
             static::loadClassDoctrineMetaData($builder);
+            static::setChangeTrackingPolicy($builder);
         } catch (\Exception $e) {
             throw new DoctrineStaticMetaException(
                 'Exception in '.__METHOD__.': '.$e->getMessage(),
@@ -75,6 +76,11 @@ trait UsesPHPMetaDataTrait
                 $e
             );
         }
+    }
+
+    public static function setChangeTrackingPolicy(ClassMetadataBuilder $builder)
+    {
+        $builder->setChangeTrackingPolicyDeferredExplicit();
     }
 
     /**

--- a/src/Entity/Traits/UsesPHPMetaDataTrait.php
+++ b/src/Entity/Traits/UsesPHPMetaDataTrait.php
@@ -78,6 +78,14 @@ trait UsesPHPMetaDataTrait
         }
     }
 
+    /**
+     * Setthing the change policy to be deferred explicit for the moment. Should consider if this needs to be
+     * configurable in the future
+     *
+     * @see http://doctrine-orm.readthedocs.io/en/latest/reference/change-tracking-policies.html
+     *
+     * @param ClassMetadataBuilder $builder
+     */
     public static function setChangeTrackingPolicy(ClassMetadataBuilder $builder)
     {
         $builder->setChangeTrackingPolicyDeferredExplicit();


### PR DESCRIPTION
This lays the foundations for #23 as it creates a method where the policy can be defined.

It also removes a performance issue when using large numbers of entities and the default Deferred Implicit policy