### PR TITLE
Improving Code Coverage, Default Values for fields

### DIFF
--- a/.phpstorm.meta.php/container.meta.php
+++ b/.phpstorm.meta.php/container.meta.php
@@ -19,6 +19,7 @@ namespace PHPSTORM_META {
                 '\EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\EntityGenerator'=>\EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\EntityGenerator::class,
                 '\Doctrine\ORM\EntityManager'=>\Doctrine\ORM\EntityManager::class,
                 '\EdmondsCommerce\DoctrineStaticMeta\EntityManager\EntityManagerFactory'=>\EdmondsCommerce\DoctrineStaticMeta\EntityManager\EntityManagerFactory::class,
+                '\EdmondsCommerce\DoctrineStaticMeta\Entity\Validation\EntityValidator'=>\EdmondsCommerce\DoctrineStaticMeta\Entity\Validation\EntityValidator::class,
                 '\EdmondsCommerce\DoctrineStaticMeta\Entity\Validation\EntityValidatorFactory'=>\EdmondsCommerce\DoctrineStaticMeta\Entity\Validation\EntityValidatorFactory::class,
                 '\EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\FieldGenerator'=>\EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\FieldGenerator::class,
                 '\EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\FileCreationTransaction'=>\EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\FileCreationTransaction::class,
@@ -30,12 +31,12 @@ namespace PHPSTORM_META {
                 '\EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\RelationsGenerator'=>\EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\RelationsGenerator::class,
                 '\EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\RelationsGenerator'=>\EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\RelationsGenerator::class,
                 '\EdmondsCommerce\DoctrineStaticMeta\Schema\Schema'=>\EdmondsCommerce\DoctrineStaticMeta\Schema\Schema::class,
+                '\EdmondsCommerce\DoctrineStaticMeta\Schema\Schema'=>\EdmondsCommerce\DoctrineStaticMeta\Schema\Schema::class,
                 '\Doctrine\ORM\Tools\SchemaTool'=>\Doctrine\ORM\Tools\SchemaTool::class,
                 '\Doctrine\ORM\Tools\SchemaValidator'=>\Doctrine\ORM\Tools\SchemaValidator::class,
                 '\EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Command\SetFieldCommand'=>\EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Command\SetFieldCommand::class,
                 '\EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Command\SetRelationCommand'=>\EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Command\SetRelationCommand::class,
-                '\EdmondsCommerce\DoctrineStaticMeta\Schema\Schema'=>\EdmondsCommerce\DoctrineStaticMeta\Schema\Schema::class,
-                '\EdmondsCommerce\DoctrineStaticMeta\Entity\Validation\EntityValidator'=>\EdmondsCommerce\DoctrineStaticMeta\Entity\Validation\EntityValidator::class,
+                '\EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\TypeHelper'=>\EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\TypeHelper::class,
             ]
         )
     );

--- a/codeTemplates/src/Entity/Fields/Interfaces/TemplateFieldNameFieldInterface.php
+++ b/codeTemplates/src/Entity/Fields/Interfaces/TemplateFieldNameFieldInterface.php
@@ -6,6 +6,8 @@ interface TemplateFieldNameFieldInterface
 {
     public const PROP_TEMPLATE_FIELD_NAME = 'templateFieldName';
 
+    public const DEFAULT_TEMPLATE_FIELD_NAME = 'defaultValue';
+
     public function getTemplateFieldName(): string;
 
     public function setTemplateFieldName(string $templateFieldName);

--- a/codeTemplates/src/Entity/Fields/Traits/TemplateFieldNameFieldTrait.php
+++ b/codeTemplates/src/Entity/Fields/Traits/TemplateFieldNameFieldTrait.php
@@ -2,9 +2,7 @@
 
 namespace TemplateNamespace\Entity\Fields\Traits;
 
-use EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces\EntityInterface;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces\ValidatedEntityInterface;
-use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Mapping\ClassMetadata as ValidatorClassMetaData;
 use TemplateNamespace\Entity\Fields\Interfaces\TemplateFieldNameFieldInterface;
 
@@ -44,6 +42,10 @@ trait TemplateFieldNameFieldTrait
      */
     public function getTemplateFieldName(): string
     {
+        if (null === $this->templateFieldName) {
+            return TemplateFieldNameFieldInterface::DEFAULT_TEMPLATE_FIELD_NAME;
+        }
+
         return $this->templateFieldName;
     }
 

--- a/src/CodeGeneration/CodeHelper.php
+++ b/src/CodeGeneration/CodeHelper.php
@@ -65,17 +65,17 @@ class CodeHelper
         return preg_replace_callback(
             '%class (.+?) implements (.+?){%s',
             function ($matches) {
-                return 'class '.$matches[1].' implements '
-                       ."\n    "
-                       .trim(
-                           implode(
-                               ",\n    ",
-                               explode(
-                                   ', ',
-                                   $matches[2]
-                               )
-                           )
-                       )."\n{";
+                return 'class ' . $matches[1] . ' implements '
+                    . "\n    "
+                    . trim(
+                        implode(
+                            ",\n    ",
+                            explode(
+                                ', ',
+                                $matches[2]
+                            )
+                        )
+                    ) . "\n{";
             },
             $generated
         );
@@ -86,16 +86,16 @@ class CodeHelper
         return preg_replace_callback(
             "%(.*?)const ([A-Z_0-9]+?) = \[([^\]]+?)\];%",
             function ($matches) {
-                return $matches[1].'const '.$matches[2]." = [\n        "
-                       .trim(
-                           implode(
-                               ",\n        ",
-                               explode(
-                                   ', ',
-                                   $matches[3]
-                               )
-                           )
-                       )."\n    ];";
+                return $matches[1] . 'const ' . $matches[2] . " = [\n        "
+                    . trim(
+                        implode(
+                            ",\n        ",
+                            explode(
+                                ', ',
+                                $matches[3]
+                            )
+                        )
+                    ) . "\n    ];";
             },
             $generated
         );
@@ -164,14 +164,14 @@ class CodeHelper
     {
         $contents = file_get_contents($filePath);
         $contents = preg_replace_callback(
-            /**
-            * @param $matches
-            *
-            * @return string
-            */
+        /**
+         * @param $matches
+         *
+         * @return string
+         */
             '%(namespace|use) (.+?);%',
             function ($matches): string {
-                return $matches[1].' '.$this->namespaceHelper->tidy($matches[2]).';';
+                return $matches[1] . ' ' . $this->namespaceHelper->tidy($matches[2]) . ';';
             },
             $contents
         );
@@ -187,7 +187,7 @@ class CodeHelper
      * @param string $filePath
      * @param string $type
      * @param string $dbalType
-     * @param bool $isNullable
+     * @param bool   $isNullable
      */
     public function replaceTypeHintsInFile(
         string $filePath,
@@ -207,7 +207,7 @@ class CodeHelper
 
         ];
 
-        $replaceNormal = [
+        $replaceNormal   = [
             ": $type;",
             "($type $",
             ": $type {",
@@ -223,7 +223,7 @@ class CodeHelper
             "@return $type|null",
             "@param $type|null",
         ];
-        $replaceRemove = [
+        $replaceRemove   = [
             ';',
             '($',
             ' {',
@@ -261,5 +261,18 @@ class CodeHelper
         $generated = $generator->generate($generateable);
         $generated = $this->postProcessGeneratedCode($generated);
         \file_put_contents($filePath, $generated);
+    }
+
+    public function getGetterMethodNameForBoolean(string $fieldName): string
+    {
+        if (0 === stripos($fieldName, 'is')) {
+            return lcfirst($fieldName);
+        }
+
+        if (0 === stripos($fieldName, 'has')) {
+            return lcfirst($fieldName);
+        }
+
+        return 'is' . ucfirst($fieldName);
     }
 }

--- a/src/CodeGeneration/CodeHelper.php
+++ b/src/CodeGeneration/CodeHelper.php
@@ -181,7 +181,7 @@ class CodeHelper
     /**
      * The standard gettype function output is not brilliantly up to date with modern PHP types
      *
-     * @param $var
+     * @param mixed $var
      *
      * @return string
      */

--- a/src/CodeGeneration/CodeHelper.php
+++ b/src/CodeGeneration/CodeHelper.php
@@ -178,31 +178,6 @@ class CodeHelper
         file_put_contents($filePath, $contents);
     }
 
-    /**
-     * The standard gettype function output is not brilliantly up to date with modern PHP types
-     *
-     * @param mixed $var
-     *
-     * @return string
-     */
-    public function getType($var): string
-    {
-        $type = \gettype($var);
-        if ('double' === $type) {
-            return 'float';
-        }
-        if ('integer' === $type) {
-            return 'int';
-        }
-        if ('NULL' === $type) {
-            return 'null';
-        }
-        if ('boolean' === $type) {
-            return 'bool';
-        }
-
-        return $type;
-    }
 
     /**
      * We use the string type hint as our default in templates

--- a/src/CodeGeneration/CodeHelper.php
+++ b/src/CodeGeneration/CodeHelper.php
@@ -65,17 +65,17 @@ class CodeHelper
         return preg_replace_callback(
             '%class (.+?) implements (.+?){%s',
             function ($matches) {
-                return 'class ' . $matches[1] . ' implements '
-                    . "\n    "
-                    . trim(
-                        implode(
-                            ",\n    ",
-                            explode(
-                                ', ',
-                                $matches[2]
-                            )
-                        )
-                    ) . "\n{";
+                return 'class '.$matches[1].' implements '
+                       ."\n    "
+                       .trim(
+                           implode(
+                               ",\n    ",
+                               explode(
+                                   ', ',
+                                   $matches[2]
+                               )
+                           )
+                       )."\n{";
             },
             $generated
         );
@@ -86,16 +86,16 @@ class CodeHelper
         return preg_replace_callback(
             "%(.*?)const ([A-Z_0-9]+?) = \[([^\]]+?)\];%",
             function ($matches) {
-                return $matches[1] . 'const ' . $matches[2] . " = [\n        "
-                    . trim(
-                        implode(
-                            ",\n        ",
-                            explode(
-                                ', ',
-                                $matches[3]
-                            )
-                        )
-                    ) . "\n    ];";
+                return $matches[1].'const '.$matches[2]." = [\n        "
+                       .trim(
+                           implode(
+                               ",\n        ",
+                               explode(
+                                   ', ',
+                                   $matches[3]
+                               )
+                           )
+                       )."\n    ];";
             },
             $generated
         );
@@ -171,13 +171,38 @@ class CodeHelper
          */
             '%(namespace|use) (.+?);%',
             function ($matches): string {
-                return $matches[1] . ' ' . $this->namespaceHelper->tidy($matches[2]) . ';';
+                return $matches[1].' '.$this->namespaceHelper->tidy($matches[2]).';';
             },
             $contents
         );
         file_put_contents($filePath, $contents);
     }
 
+    /**
+     * The standard gettype function output is not brilliantly up to date with modern PHP types
+     *
+     * @param $var
+     *
+     * @return string
+     */
+    public function getType($var): string
+    {
+        $type = \gettype($var);
+        if ('double' === $type) {
+            return 'float';
+        }
+        if ('integer' === $type) {
+            return 'int';
+        }
+        if ('NULL' === $type) {
+            return 'null';
+        }
+        if ('boolean' === $type) {
+            return 'bool';
+        }
+
+        return $type;
+    }
 
     /**
      * We use the string type hint as our default in templates
@@ -254,7 +279,7 @@ class CodeHelper
         $generator = new CodeFileGenerator(
             [
                 'generateDocblock'   => false,
-                'declareStrictTypes' => true
+                'declareStrictTypes' => true,
             ]
         );
 
@@ -273,6 +298,6 @@ class CodeHelper
             return lcfirst($fieldName);
         }
 
-        return 'is' . ucfirst($fieldName);
+        return 'is'.ucfirst($fieldName);
     }
 }

--- a/src/CodeGeneration/Command/GenerateFieldCommand.php
+++ b/src/CodeGeneration/Command/GenerateFieldCommand.php
@@ -77,7 +77,7 @@ class GenerateFieldCommand extends AbstractCommand
                         new InputOption(
                             self::OPT_DEFAULT_VALUE,
                             self::OPT_DEFAULT_VALUE_SHORT,
-                            InputOption::VALUE_REQUIRED,
+                            InputOption::VALUE_OPTIONAL,
                             self::DEFINITION_DEFAULT_VALUE,
                             null
                         ),
@@ -125,7 +125,7 @@ class GenerateFieldCommand extends AbstractCommand
                 $input->getOption(self::OPT_FQN),
                 $input->getOption(self::OPT_TYPE),
                 null,
-                $input->getOption(self::OPT_DEFAULT_VALUE),
+                $input->getOption(self::OPT_DEFAULT_VALUE) ?? null,
                 $input->getOption(self::OPT_IS_UNIQUE)
             );
 

--- a/src/CodeGeneration/Command/GenerateFieldCommand.php
+++ b/src/CodeGeneration/Command/GenerateFieldCommand.php
@@ -17,12 +17,13 @@ class GenerateFieldCommand extends AbstractCommand
     public const DEFINITION_NAME = 'The fully qualified name of the property you want to generate';
 
     public const OPT_TYPE        = 'field-property-doctrine-type';
-    public const OPT_TYPE_SHORT  = 'd';
+    public const OPT_TYPE_SHORT  = 'y';
     public const DEFINITION_TYPE = 'The data type of the property you want to generate';
 
-    public const OPT_NOT_NULLABLE        = 'not-nullable';
-    public const OPT_NOT_NULLABLE_SHORT  = 'z';
-    public const DEFINITION_NOT_NULLABLE = 'This field will not be nullable';
+    public const OPT_DEFAULT_VALUE        = 'default';
+    public const OPT_DEFAULT_VALUE_SHORT  = 'd';
+    public const DEFINITION_DEFAULT_VALUE = 'The default value, defaults to null '
+                                            .'(which also marks the field as nullable)';
 
     public const OPT_IS_UNIQUE        = 'is-unique';
     public const OPT_IS_UNIQUE_SHORT  = 'u';
@@ -74,10 +75,11 @@ class GenerateFieldCommand extends AbstractCommand
                             self::DEFINITION_TYPE
                         ),
                         new InputOption(
-                            self::OPT_NOT_NULLABLE,
-                            self::OPT_NOT_NULLABLE_SHORT,
-                            InputOption::VALUE_NONE,
-                            self::DEFINITION_NOT_NULLABLE
+                            self::OPT_DEFAULT_VALUE,
+                            self::OPT_DEFAULT_VALUE_SHORT,
+                            InputOption::VALUE_OPTIONAL,
+                            self::DEFINITION_DEFAULT_VALUE,
+                            null
                         ),
                         new InputOption(
                             self::OPT_IS_UNIQUE,
@@ -123,7 +125,7 @@ class GenerateFieldCommand extends AbstractCommand
                 $input->getOption(self::OPT_FQN),
                 $input->getOption(self::OPT_TYPE),
                 null,
-                !(bool)$input->getOption(self::OPT_NOT_NULLABLE),
+                $input->getOption(self::OPT_DEFAULT_VALUE),
                 $input->getOption(self::OPT_IS_UNIQUE)
             );
 

--- a/src/CodeGeneration/Command/GenerateFieldCommand.php
+++ b/src/CodeGeneration/Command/GenerateFieldCommand.php
@@ -77,7 +77,7 @@ class GenerateFieldCommand extends AbstractCommand
                         new InputOption(
                             self::OPT_DEFAULT_VALUE,
                             self::OPT_DEFAULT_VALUE_SHORT,
-                            InputOption::VALUE_OPTIONAL,
+                            InputOption::VALUE_REQUIRED,
                             self::DEFINITION_DEFAULT_VALUE,
                             null
                         ),

--- a/src/CodeGeneration/Generator/FieldGenerator.php
+++ b/src/CodeGeneration/Generator/FieldGenerator.php
@@ -173,7 +173,7 @@ class FieldGenerator extends AbstractGenerator
         $defaultValue = null,
         bool $isUnique = false
     ): string {
-        $this->validateArguments($fieldFqn, $dbalType, $phpType, $defaultValue);
+        $this->validateArguments($fieldFqn, $dbalType, $phpType);
         $this->setupClassProperties($fieldFqn, $dbalType, $phpType, $defaultValue, $isUnique);
 
         $this->ensurePathExists($this->fieldsPath);
@@ -187,8 +187,7 @@ class FieldGenerator extends AbstractGenerator
     protected function validateArguments(
         string $fieldFqn,
         string $dbalType,
-        ?string $phpType,
-        $defaultValue
+        ?string $phpType
     ): void {
         if (false === strpos($fieldFqn, AbstractGenerator::ENTITY_FIELD_TRAIT_NAMESPACE)) {
             throw new \InvalidArgumentException(
@@ -209,16 +208,6 @@ class FieldGenerator extends AbstractGenerator
                 'phpType must be either null or one of MappingHelper::PHP_TYPES'
             );
         }
-        if (null !== $defaultValue) {
-            $this->phpType    = $phpType ?? $this->getPhpTypeForDbalType();
-            $defaultValueType = gettype($defaultValue);
-            if ($defaultValueType !== $this->phpType) {
-                throw new \InvalidArgumentException(
-                    'default value '.$defaultValue.' has the type: '.$defaultValueType
-                    .' whereas the phpType for this field has been set as '.$this->phpType.', these do not match up'
-                );
-            }
-        }
     }
 
     protected function setupClassProperties(
@@ -230,6 +219,16 @@ class FieldGenerator extends AbstractGenerator
     ) {
         $this->dbalType = $dbalType;
         $this->phpType  = $phpType ?? $this->getPhpTypeForDbalType();
+
+        if (null !== $defaultValue) {
+            $defaultValueType = gettype($defaultValue);
+            if ($defaultValueType !== $this->phpType) {
+                throw new \InvalidArgumentException(
+                    'default value '.$defaultValue.' has the type: '.$defaultValueType
+                    .' whereas the phpType for this field has been set as '.$this->phpType.', these do not match up'
+                );
+            }
+        }
 
         $this->defaultValue = $defaultValue;
         $this->isNullable   = (null === $defaultValue);

--- a/src/CodeGeneration/Generator/FieldGenerator.php
+++ b/src/CodeGeneration/Generator/FieldGenerator.php
@@ -260,7 +260,7 @@ class FieldGenerator extends AbstractGenerator
      *
      * This function takes the string value and normalises it into the correct value based on the expected type
      *
-     * @param        $defaultValue
+     * @param mixed  $defaultValue
      * @param string $expectedType
      *
      * @return mixed

--- a/src/CodeGeneration/Generator/FieldGenerator.php
+++ b/src/CodeGeneration/Generator/FieldGenerator.php
@@ -473,7 +473,7 @@ class FieldGenerator extends AbstractGenerator
         MappingHelper::$mappingHelperMethodName(
             [{$this->classy}FieldInterface::PROP_{$this->consty}],
             \$builder,
-            {$this->classy}FieldInterface::PROP_{$this->consty}_DEFAULT,
+            {$this->classy}FieldInterface::DEFAULT_{$this->consty},
             $isUniqueString
         );                        
 ";

--- a/src/CodeGeneration/Generator/FieldGenerator.php
+++ b/src/CodeGeneration/Generator/FieldGenerator.php
@@ -272,36 +272,44 @@ class FieldGenerator extends AbstractGenerator
         }
         switch ($expectedType) {
             case 'string':
-                return (string)$defaultValue;
+                return trim((string)$defaultValue);
                 break;
             case 'bool':
                 if (\is_bool($defaultValue)) {
                     return $defaultValue;
                 }
+                $defaultValue = trim($defaultValue);
                 if (0 === strcasecmp('true', $defaultValue)) {
                     return true;
                 }
                 if (0 === strcasecmp('false', $defaultValue)) {
                     return false;
                 }
+                throw new \RuntimeException('Invalid '.$expectedType.' default value: '.$defaultValue);
                 break;
             case 'int':
+                $defaultValue = trim((string)$defaultValue);
                 if (is_numeric($defaultValue)) {
                     return (int)$defaultValue;
                 }
+                throw new \RuntimeException('Invalid '.$expectedType.' default value: '.$defaultValue);
                 break;
             case 'float':
+                $defaultValue = trim((string)$defaultValue);
                 if (is_numeric($defaultValue)) {
                     return (float)$defaultValue;
                 }
+                throw new \RuntimeException('Invalid '.$expectedType.' default value: '.$defaultValue);
                 break;
             case '\DateTime':
+                $defaultValue = trim($defaultValue);
                 switch (true) {
                     case (0 === strcasecmp('current', $defaultValue)):
                     case (0 === strcasecmp('current_timestamp', $defaultValue)):
                     case (0 === strcasecmp('now', $defaultValue)):
                         return MappingHelper::DATETIME_DEFAULT_CURRENT_TIME_STAMP;
                 }
+                throw new \RuntimeException('Invalid '.$expectedType.' default value: '.$defaultValue);
                 break;
             default:
                 throw new \RuntimeException('hit unexpected type '.$expectedType.' in '.__METHOD__);

--- a/src/CodeGeneration/Generator/FieldGenerator.php
+++ b/src/CodeGeneration/Generator/FieldGenerator.php
@@ -95,7 +95,7 @@ class FieldGenerator extends AbstractGenerator
             $fieldInterface           = PhpInterface::fromFile($fieldInterfaceReflection->getFileName());
         } catch (\Exception $e) {
             throw new DoctrineStaticMetaException(
-                'Failed loading the entity or field from FQN: '.$e->getMessage(),
+                'Failed loading the entity or field from FQN: ' . $e->getMessage(),
                 $e->getCode(),
                 $e
             );
@@ -133,9 +133,9 @@ class FieldGenerator extends AbstractGenerator
     ): string {
         if (false === strpos($fieldFqn, AbstractGenerator::ENTITY_FIELD_TRAIT_NAMESPACE)) {
             throw new \InvalidArgumentException(
-                'Fully qualified name [ '.$fieldFqn.' ]'
-                .' does not include [ '.AbstractGenerator::ENTITY_FIELD_TRAIT_NAMESPACE.' ].'."\n"
-                .'Please ensure you pass in the full namespace qualified field name'
+                'Fully qualified name [ ' . $fieldFqn . ' ]'
+                . ' does not include [ ' . AbstractGenerator::ENTITY_FIELD_TRAIT_NAMESPACE . ' ].' . "\n"
+                . 'Please ensure you pass in the full namespace qualified field name'
             );
         }
         if (false === \in_array($dbalType, MappingHelper::ALL_DBAL_TYPES, true)) {
@@ -165,11 +165,11 @@ class FieldGenerator extends AbstractGenerator
         );
 
         $this->fieldsPath = $this->codeHelper->resolvePath(
-            $this->pathToProjectRoot.'/'.implode('/', $traitSubDirectories)
+            $this->pathToProjectRoot . '/' . implode('/', $traitSubDirectories)
         );
 
         $this->fieldsInterfacePath = $this->codeHelper->resolvePath(
-            $this->pathToProjectRoot.'/'.implode('/', $interfaceSubDirectories)
+            $this->pathToProjectRoot . '/' . implode('/', $interfaceSubDirectories)
         );
 
         $this->classy             = Inflector::classify($className);
@@ -206,9 +206,9 @@ class FieldGenerator extends AbstractGenerator
     {
         if (!\in_array($this->dbalType, MappingHelper::COMMON_TYPES, true)) {
             throw new DoctrineStaticMetaException(
-                'Field type of '.$this->dbalType.' is not one of MappingHelper::COMMON_TYPES'
-                ."\n\nYou can only use this dbal type if you pass in the explicit phpType as well "
-                ."\n\nAlternatively, suggest you set the type as string and then edit the generated code as you see fit"
+                'Field type of ' . $this->dbalType . ' is not one of MappingHelper::COMMON_TYPES'
+                . "\n\nYou can only use this dbal type if you pass in the explicit phpType as well "
+                . "\n\nAlternatively, suggest you set the type as string and then edit the generated code as you see fit"
             );
         }
 
@@ -221,7 +221,7 @@ class FieldGenerator extends AbstractGenerator
      */
     protected function generateInterface(bool $isNullable): void
     {
-        $filePath = $this->fieldsInterfacePath.'/'.$this->classy.'FieldInterface.php';
+        $filePath = $this->fieldsInterfacePath . '/' . $this->classy . 'FieldInterface.php';
         $this->assertFileDoesNotExist($filePath, 'Interface');
         try {
             $this->fileSystem->copy(
@@ -236,7 +236,9 @@ class FieldGenerator extends AbstractGenerator
                 $isNullable
             );
         } catch (\Exception $e) {
-            throw new DoctrineStaticMetaException('Error in '.__METHOD__.': '.$e->getMessage(), $e->getCode(), $e);
+            throw new DoctrineStaticMetaException('Error in ' . __METHOD__ . ': ' . $e->getMessage(),
+                                                  $e->getCode(),
+                                                  $e);
         }
     }
 
@@ -277,9 +279,9 @@ class FieldGenerator extends AbstractGenerator
         if ($this->phpType !== 'bool') {
             return;
         }
-        $this->findReplace(' get', ' is', $filePath);
-        $this->findReplace(' isIs', ' is', $filePath);
-        $this->findReplace(' isis', ' is', $filePath);
+        $replaceName = $this->codeHelper->getGetterMethodNameForBoolean($this->classy);
+        $findName    = 'get' . $this->classy;
+        $this->findReplace($findName, $replaceName, $filePath);
     }
 
     /**
@@ -305,7 +307,7 @@ class FieldGenerator extends AbstractGenerator
      */
     protected function generateTrait(bool $isNullable, bool $isUnique): string
     {
-        $filePath = $this->fieldsPath.'/'.$this->classy.'FieldTrait.php';
+        $filePath = $this->fieldsPath . '/' . $this->classy . 'FieldTrait.php';
         $this->assertFileDoesNotExist($filePath, 'Trait');
         try {
             $this->fileSystem->copy(
@@ -316,8 +318,8 @@ class FieldGenerator extends AbstractGenerator
             $this->traitPostCopy($filePath);
             $trait = PhpTrait::fromFile($filePath);
             $trait->setMethod($this->getPropertyMetaMethod($isNullable, $isUnique));
-            $trait->addUseStatement('\\'.MappingHelper::class);
-            $trait->addUseStatement('\\'.ClassMetadataBuilder::class);
+            $trait->addUseStatement('\\' . MappingHelper::class);
+            $trait->addUseStatement('\\' . ClassMetadataBuilder::class);
             $this->codeHelper->generate($trait, $filePath);
             $this->codeHelper->replaceTypeHintsInFile(
                 $filePath,
@@ -328,7 +330,9 @@ class FieldGenerator extends AbstractGenerator
 
             return $trait->getQualifiedName();
         } catch (\Exception $e) {
-            throw new DoctrineStaticMetaException('Error in '.__METHOD__.': '.$e->getMessage(), $e->getCode(), $e);
+            throw new DoctrineStaticMetaException('Error in ' . __METHOD__ . ': ' . $e->getMessage(),
+                                                  $e->getCode(),
+                                                  $e);
         }
     }
 
@@ -343,14 +347,14 @@ class FieldGenerator extends AbstractGenerator
      */
     protected function getPropertyMetaMethod(bool $isNullable, bool $isUnique): PhpMethod
     {
-        $name   = UsesPHPMetaDataInterface::METHOD_PREFIX_GET_PROPERTY_DOCTRINE_META.$this->classy;
+        $name   = UsesPHPMetaDataInterface::METHOD_PREFIX_GET_PROPERTY_DOCTRINE_META . $this->classy;
         $method = PhpMethod::create($name);
         $method->setStatic(true);
         $method->setVisibility('public');
         $method->setParameters(
             [PhpParameter::create('builder')->setType('ClassMetadataBuilder')]
         );
-        $mappingHelperMethodName = 'setSimple'.ucfirst(strtolower($this->dbalType)).'Fields';
+        $mappingHelperMethodName = 'setSimple' . ucfirst(strtolower($this->dbalType)) . 'Fields';
         $isNullableString        = $isNullable ? 'true' : 'false';
         $isUniqueString          = $isUnique ? 'true' : 'false';
         $methodBody              = "

--- a/src/CodeGeneration/TypeHelper.php
+++ b/src/CodeGeneration/TypeHelper.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\CodeGeneration;
+
+use EdmondsCommerce\DoctrineStaticMeta\MappingHelper;
+
+class TypeHelper
+{
+
+    /**
+     * The standard gettype function output is not brilliantly up to date with modern PHP types
+     *
+     * @param mixed $var
+     *
+     * @return string
+     */
+    public function getType($var): string
+    {
+        $type = \gettype($var);
+        if ('double' === $type) {
+            return 'float';
+        }
+        if ('integer' === $type) {
+            return 'int';
+        }
+        if ('NULL' === $type) {
+            return 'null';
+        }
+        if ('boolean' === $type) {
+            return 'bool';
+        }
+
+        return $type;
+    }
+
+    /**
+     * When a default is passed in via CLI then the type can not be expected to be set correctly
+     *
+     * This function takes the string value and normalises it into the correct value based on the expected type
+     *
+     * @param mixed  $value
+     * @param string $expectedType
+     *
+     * @return mixed
+     */
+    public function normaliseValueToType($value, string $expectedType)
+    {
+        if (null === $value) {
+            return null;
+        }
+        switch ($expectedType) {
+            case 'string':
+                return $this->normaliseString($value);
+            case 'bool':
+                return $this->normaliseBool($value);
+            case 'int':
+                return $this->normaliseInt($value);
+            case 'float':
+                return $this->normaliseFloat($value);
+            case '\DateTime':
+                return $this->normaliseDateTime($value);
+            default:
+                throw new \RuntimeException('hit unexpected type '.$expectedType.' in '.__METHOD__);
+        }
+    }
+
+    private function normaliseString($value): string
+    {
+        return trim((string)$value);
+    }
+
+    private function normaliseBool($value): bool
+    {
+        if (\is_bool($value)) {
+            return $value;
+        }
+        $value = trim($value);
+        if (0 === strcasecmp('true', $value)) {
+            return true;
+        }
+        if (0 === strcasecmp('false', $value)) {
+            return false;
+        }
+        throw new \RuntimeException('Invalid bool value: '.$value);
+    }
+
+    private function normaliseInt($value): int
+    {
+        $value = trim((string)$value);
+        if (is_numeric($value)) {
+            return (int)$value;
+        }
+        throw new \RuntimeException('Invalid int default value: '.$value);
+    }
+
+    private function normaliseFloat($value): float
+    {
+        $value = trim((string)$value);
+        if (is_numeric($value)) {
+            return (float)$value;
+        }
+        throw new \RuntimeException('Invalid float default value: '.$value);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return int
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     */
+    private function normaliseDateTime($value): int
+    {
+        $value = trim($value);
+        switch (true) {
+            case (0 === strcasecmp('current', $value)):
+            case (0 === strcasecmp('current_timestamp', $value)):
+            case (0 === strcasecmp('now', $value)):
+                return MappingHelper::DATETIME_DEFAULT_CURRENT_TIME_STAMP;
+        }
+        throw new \RuntimeException('Invalid DateTime default value: '.$value);
+    }
+}

--- a/src/Container.php
+++ b/src/Container.php
@@ -19,6 +19,7 @@ use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\FieldGenerator;
 use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\FileCreationTransaction;
 use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\RelationsGenerator;
 use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\NamespaceHelper;
+use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\TypeHelper;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces\Validation\EntityValidatorInterface;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Validation\EntityValidator;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Validation\EntityValidatorFactory;
@@ -61,6 +62,7 @@ class Container implements ContainerInterface
         EntityGenerator::class,
         EntityManager::class,
         EntityManagerFactory::class,
+        EntityValidator::class,
         EntityValidatorFactory::class,
         FieldGenerator::class,
         FileCreationTransaction::class,
@@ -72,12 +74,12 @@ class Container implements ContainerInterface
         RelationsGenerator::class,
         RelationsGenerator::class,
         Schema::class,
+        Schema::class,
         SchemaTool::class,
         SchemaValidator::class,
         SetFieldCommand::class,
         SetRelationCommand::class,
-        Schema::class,
-        EntityValidator::class,
+        TypeHelper::class,
     ];
 
     /**

--- a/src/Entity/Fields/Interfaces/Flag/ApprovedFieldInterface.php
+++ b/src/Entity/Fields/Interfaces/Flag/ApprovedFieldInterface.php
@@ -6,6 +6,8 @@ interface ApprovedFieldInterface
 {
     public const PROP_APPROVED = 'approved';
 
+    public const DEFAULT_APPROVED = false;
+
     public function isApproved(): bool;
 
     public function setApproved(bool $approved);

--- a/src/Entity/Fields/Interfaces/Flag/DefaultFieldInterface.php
+++ b/src/Entity/Fields/Interfaces/Flag/DefaultFieldInterface.php
@@ -6,6 +6,8 @@ interface DefaultFieldInterface
 {
     public const PROP_DEFAULT = 'default';
 
+    public const DEFAULT_DEFAULT = false;
+
     public function isDefault(): bool;
 
     public function setDefault(bool $default);

--- a/src/Entity/Fields/Interfaces/PrimaryKey/IdFieldInterface.php
+++ b/src/Entity/Fields/Interfaces/PrimaryKey/IdFieldInterface.php
@@ -4,7 +4,7 @@ namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\PrimaryKey
 
 interface IdFieldInterface
 {
-    public const PROPERTY_NAME= 'id';
+    public const PROP_ID = 'id';
 
     public function getId();
 }

--- a/src/Entity/Fields/Traits/Attribute/QtyFieldTrait.php
+++ b/src/Entity/Fields/Traits/Attribute/QtyFieldTrait.php
@@ -29,8 +29,7 @@ trait QtyFieldTrait
     {
         MappingHelper::setSimpleIntegerFields(
             [QtyFieldInterface::PROP_QTY],
-            $builder,
-            true
+            $builder
         );
     }
 

--- a/src/Entity/Fields/Traits/Date/ActionedDateFieldTrait.php
+++ b/src/Entity/Fields/Traits/Date/ActionedDateFieldTrait.php
@@ -6,7 +6,6 @@ namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Date;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Date\ActionedDateFieldInterface;
-use EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces\EntityInterface;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces\ValidatedEntityInterface;
 use EdmondsCommerce\DoctrineStaticMeta\MappingHelper;
 use Symfony\Component\Validator\Constraints\DateTime;
@@ -29,8 +28,7 @@ trait ActionedDateFieldTrait
     {
         MappingHelper::setSimpleDatetimeFields(
             [ActionedDateFieldInterface::PROP_ACTIONED_DATE],
-            $builder,
-            true
+            $builder
         );
     }
 

--- a/src/Entity/Fields/Traits/Date/ActivatedDateFieldTrait.php
+++ b/src/Entity/Fields/Traits/Date/ActivatedDateFieldTrait.php
@@ -29,8 +29,7 @@ trait ActivatedDateFieldTrait
     {
         MappingHelper::setSimpleDatetimeFields(
             [ActivatedDateFieldInterface::PROP_ACTIVATED_DATE],
-            $builder,
-            true
+            $builder
         );
     }
 

--- a/src/Entity/Fields/Traits/Date/CompletedDateFieldTrait.php
+++ b/src/Entity/Fields/Traits/Date/CompletedDateFieldTrait.php
@@ -29,8 +29,7 @@ trait CompletedDateFieldTrait
     {
         MappingHelper::setSimpleDatetimeFields(
             [CompletedDateFieldInterface::PROP_COMPLETED_DATE],
-            $builder,
-            true
+            $builder
         );
     }
 

--- a/src/Entity/Fields/Traits/Date/DeactivatedDateFieldTrait.php
+++ b/src/Entity/Fields/Traits/Date/DeactivatedDateFieldTrait.php
@@ -29,8 +29,7 @@ trait DeactivatedDateFieldTrait
     {
         MappingHelper::setSimpleDatetimeFields(
             [DeactivatedDateFieldInterface::PROP_DEACTIVATED_DATE],
-            $builder,
-            true
+            $builder
         );
     }
 

--- a/src/Entity/Fields/Traits/Date/TimestampFieldTrait.php
+++ b/src/Entity/Fields/Traits/Date/TimestampFieldTrait.php
@@ -29,8 +29,7 @@ trait TimestampFieldTrait
     {
         MappingHelper::setSimpleDatetimeFields(
             [TimestampFieldInterface::PROP_TIMESTAMP],
-            $builder,
-            true
+            $builder
         );
     }
 

--- a/src/Entity/Fields/Traits/Flag/ApprovedFieldTrait.php
+++ b/src/Entity/Fields/Traits/Flag/ApprovedFieldTrait.php
@@ -28,10 +28,11 @@ trait ApprovedFieldTrait
     public static function metaForIsApproved(ClassMetadataBuilder $builder): void
     {
         $fieldBuilder = new FieldBuilder($builder, [
-            'default'   => ApprovedFieldInterface::DEFAULT_APPROVED,
-            'fieldName' => ApprovedFieldInterface::PROP_APPROVED,
-            'type'      => MappingHelper::TYPE_BOOLEAN,
-            'nullable'  => false,
+            'default'    => ApprovedFieldInterface::DEFAULT_APPROVED,
+            'fieldName'  => ApprovedFieldInterface::PROP_APPROVED,
+            'columnName' => MappingHelper::getColumnNameForField(ApprovedFieldInterface::PROP_APPROVED),
+            'type'       => MappingHelper::TYPE_BOOLEAN,
+            'nullable'   => false,
         ]);
         $fieldBuilder->build();
     }

--- a/src/Entity/Fields/Traits/Flag/ApprovedFieldTrait.php
+++ b/src/Entity/Fields/Traits/Flag/ApprovedFieldTrait.php
@@ -28,7 +28,7 @@ trait ApprovedFieldTrait
     public static function metaForIsApproved(ClassMetadataBuilder $builder): void
     {
         $fieldBuilder = new FieldBuilder($builder, [
-            'default'   => false,
+            'default'   => ApprovedFieldInterface::DEFAULT_APPROVED,
             'fieldName' => ApprovedFieldInterface::PROP_APPROVED,
             'type'      => MappingHelper::TYPE_BOOLEAN,
             'nullable'  => false,
@@ -56,6 +56,10 @@ trait ApprovedFieldTrait
      */
     public function isApproved(): bool
     {
+        if (null === $this->approved) {
+            return ApprovedFieldInterface::DEFAULT_APPROVED;
+        }
+
         return $this->approved;
     }
 

--- a/src/Entity/Fields/Traits/Flag/ApprovedFieldTrait.php
+++ b/src/Entity/Fields/Traits/Flag/ApprovedFieldTrait.php
@@ -5,8 +5,8 @@ namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Flag;
 // phpcs:disable
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
+use Doctrine\ORM\Mapping\Builder\FieldBuilder;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Flag\ApprovedFieldInterface;
-use EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces\EntityInterface;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces\ValidatedEntityInterface;
 use EdmondsCommerce\DoctrineStaticMeta\MappingHelper;
 use Symfony\Component\Validator\Constraints\NotNull;
@@ -27,11 +27,13 @@ trait ApprovedFieldTrait
      */
     public static function metaForIsApproved(ClassMetadataBuilder $builder): void
     {
-        MappingHelper::setSimpleBooleanFields(
-            [ApprovedFieldInterface::PROP_APPROVED],
-            $builder,
-            false
-        );
+        $fieldBuilder = new FieldBuilder($builder, [
+            'default'   => false,
+            'fieldName' => ApprovedFieldInterface::PROP_APPROVED,
+            'type'      => MappingHelper::TYPE_BOOLEAN,
+            'nullable'  => false,
+        ]);
+        $fieldBuilder->build();
     }
 
     /**

--- a/src/Entity/Fields/Traits/Flag/DefaultFieldTrait.php
+++ b/src/Entity/Fields/Traits/Flag/DefaultFieldTrait.php
@@ -29,7 +29,7 @@ trait DefaultFieldTrait
     {
         $fieldBuilder = new FieldBuilder($builder, [
             'default'   => DefaultFieldInterface::DEFAULT_DEFAULT,
-            'fieldName' => DefaultFieldInterface::PROP_DEFAULT,
+            'fieldName' => '`'.DefaultFieldInterface::PROP_DEFAULT.'`',
             'type'      => MappingHelper::TYPE_BOOLEAN,
             'nullable'  => false,
         ]);

--- a/src/Entity/Fields/Traits/Flag/DefaultFieldTrait.php
+++ b/src/Entity/Fields/Traits/Flag/DefaultFieldTrait.php
@@ -5,8 +5,8 @@ namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Flag;
 // phpcs:disable
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
+use Doctrine\ORM\Mapping\Builder\FieldBuilder;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Flag\DefaultFieldInterface;
-use EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces\EntityInterface;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces\ValidatedEntityInterface;
 use EdmondsCommerce\DoctrineStaticMeta\MappingHelper;
 use Symfony\Component\Validator\Constraints\NotNull;
@@ -27,11 +27,13 @@ trait DefaultFieldTrait
      */
     public static function metaForIsDefault(ClassMetadataBuilder $builder): void
     {
-        MappingHelper::setSimpleBooleanFields(
-            [DefaultFieldInterface::PROP_DEFAULT],
-            $builder,
-            false
-        );
+        $fieldBuilder = new FieldBuilder($builder, [
+            'default'   => DefaultFieldInterface::DEFAULT_DEFAULT,
+            'fieldName' => DefaultFieldInterface::PROP_DEFAULT,
+            'type'      => MappingHelper::TYPE_BOOLEAN,
+            'nullable'  => false,
+        ]);
+        $fieldBuilder->build();
     }
 
     /**
@@ -54,6 +56,10 @@ trait DefaultFieldTrait
      */
     public function isDefault(): bool
     {
+        if (null === $this->default) {
+            return DefaultFieldInterface::DEFAULT_DEFAULT;
+        }
+
         return $this->default;
     }
 

--- a/src/Entity/Fields/Traits/Flag/DefaultFieldTrait.php
+++ b/src/Entity/Fields/Traits/Flag/DefaultFieldTrait.php
@@ -28,10 +28,11 @@ trait DefaultFieldTrait
     public static function metaForIsDefault(ClassMetadataBuilder $builder): void
     {
         $fieldBuilder = new FieldBuilder($builder, [
-            'default'   => DefaultFieldInterface::DEFAULT_DEFAULT,
-            'fieldName' => '`'.DefaultFieldInterface::PROP_DEFAULT.'`',
-            'type'      => MappingHelper::TYPE_BOOLEAN,
-            'nullable'  => false,
+            'default'    => DefaultFieldInterface::DEFAULT_DEFAULT,
+            'fieldName'  => DefaultFieldInterface::PROP_DEFAULT,
+            'columnName' => MappingHelper::getColumnNameForField(DefaultFieldInterface::PROP_DEFAULT),
+            'type'       => MappingHelper::TYPE_BOOLEAN,
+            'nullable'   => false,
         ]);
         $fieldBuilder->build();
     }

--- a/src/Entity/Fields/Traits/Person/EmailFieldTrait.php
+++ b/src/Entity/Fields/Traits/Person/EmailFieldTrait.php
@@ -29,8 +29,7 @@ trait EmailFieldTrait
     {
         MappingHelper::setSimpleStringFields(
             [EmailFieldInterface::PROP_EMAIL],
-            $builder,
-            true
+            $builder
         );
     }
 

--- a/src/Entity/Repositories/AbstractEntityRepository.php
+++ b/src/Entity/Repositories/AbstractEntityRepository.php
@@ -46,7 +46,7 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
      * @param EntityManager      $entityManager
      * @param ClassMetadata|null $metaData
      */
-    public function __construct(EntityManager $entityManager, ?ClassMetadata $metaData)
+    public function __construct(EntityManager $entityManager, ?ClassMetadata $metaData = null)
     {
         $this->entityManager = $entityManager;
         $this->metaData      = $metaData;
@@ -66,16 +66,16 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
     protected function getEntityFqn(): string
     {
         return '\\'.\str_replace(
-            [
+                [
                     'Entity\\Repositories',
                     'Repository',
                 ],
-            [
+                [
                     'Entities',
                     '',
                 ],
-            static::class
-        );
+                static::class
+            );
     }
 
     public function find($id, $lockMode = null, $lockVersion = null)

--- a/src/MappingHelper.php
+++ b/src/MappingHelper.php
@@ -119,15 +119,16 @@ class MappingHelper
     ];
 
     /**
-     * Wrap the name in backticks
-     *
-     * @param string $name
+     * @param string $entityFqn
      *
      * @return string
+     * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    public static function backticks(string $name): string
+    public static function getPluralForFqn(string $entityFqn): string
     {
-        return '`'.$name.'`';
+        $singular = self::getSingularForFqn($entityFqn);
+
+        return Inflector::pluralize($singular);
     }
 
     /**
@@ -141,19 +142,6 @@ class MappingHelper
         $shortName = self::getShortNameForFqn($entityFqn);
 
         return lcfirst(Inflector::singularize($shortName));
-    }
-
-    /**
-     * @param string $entityFqn
-     *
-     * @return string
-     * @SuppressWarnings(PHPMD.StaticAccess)
-     */
-    public static function getPluralForFqn(string $entityFqn): string
-    {
-        $singular = self::getSingularForFqn($entityFqn);
-
-        return Inflector::pluralize($singular);
     }
 
     /**
@@ -189,6 +177,18 @@ class MappingHelper
     }
 
     /**
+     * Wrap the name in backticks
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    public static function backticks(string $name): string
+    {
+        return '`'.$name.'`';
+    }
+
+    /**
      * Set bog standard string fields quickly in bulk
      *
      * @param array                $fields
@@ -206,7 +206,10 @@ class MappingHelper
         bool $isUnique = false
     ): void {
         if (null !== $default && !\is_string($default)) {
-            throw new \InvalidArgumentException('Invalid default value '.$default);
+            throw new \InvalidArgumentException(
+                'Invalid default value '.$default
+                .' with type '.gettype($default)
+            );
         }
         foreach ($fields as $field) {
             $fieldBuilder = new FieldBuilder(
@@ -245,7 +248,10 @@ class MappingHelper
         $default = null
     ): void {
         if (null !== $default && !\is_string($default)) {
-            throw new \InvalidArgumentException('Invalid default value '.$default);
+            throw new \InvalidArgumentException(
+                'Invalid default value '.$default
+                .' with type '.gettype($default)
+            );
         }
         foreach ($fields as $field) {
             $fieldBuilder = new FieldBuilder(
@@ -279,7 +285,10 @@ class MappingHelper
         $default = null
     ): void {
         if (null !== $default && !\is_float($default)) {
-            throw new \InvalidArgumentException('Invalid default value '.$default);
+            throw new \InvalidArgumentException(
+                'Invalid default value '.$default
+                .' with type '.gettype($default)
+            );
         }
         foreach ($fields as $field) {
             $fieldBuilder = new FieldBuilder(
@@ -315,7 +324,10 @@ class MappingHelper
         $default = null
     ): void {
         if (null !== $default && !\is_float($default)) {
-            throw new \InvalidArgumentException('Invalid default value '.$default);
+            throw new \InvalidArgumentException(
+                'Invalid default value '.$default
+                .' with type '.gettype($default)
+            );
         }
         foreach ($fields as $field) {
             $fieldBuilder = new FieldBuilder(
@@ -395,7 +407,10 @@ class MappingHelper
         bool $isUnique = false
     ): void {
         if (null !== $default && !\is_int($default)) {
-            throw new \InvalidArgumentException('Invalid default value '.$default);
+            throw new \InvalidArgumentException(
+                'Invalid default value '.$default
+                .' with type '.gettype($default)
+            );
         }
         foreach ($fields as $field) {
             $fieldBuilder = new FieldBuilder(
@@ -430,7 +445,10 @@ class MappingHelper
         $default = null
     ): void {
         if (null !== $default && !\is_bool($default)) {
-            throw new \InvalidArgumentException('Invalid default value '.$default);
+            throw new \InvalidArgumentException(
+                'Invalid default value '.$default
+                .' with type '.gettype($default)
+            );
         }
         foreach ($fields as $field) {
             $fieldBuilder = new FieldBuilder(

--- a/src/MappingHelper.php
+++ b/src/MappingHelper.php
@@ -9,6 +9,15 @@ use Doctrine\ORM\Mapping\Builder\FieldBuilder;
 use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\NamespaceHelper;
 use EdmondsCommerce\DoctrineStaticMeta\Schema\Database;
 
+/**
+ * Class MappingHelper
+ *
+ * Helper functions to assist with setting up Doctrine mapping meta data
+ *
+ * @package EdmondsCommerce\DoctrineStaticMeta
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
 class MappingHelper
 {
 
@@ -122,7 +131,6 @@ class MappingHelper
      * @param string $entityFqn
      *
      * @return string
-     * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public static function getPluralForFqn(string $entityFqn): string
     {
@@ -135,7 +143,6 @@ class MappingHelper
      * @param string $entityFqn
      *
      * @return string
-     * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public static function getSingularForFqn(string $entityFqn): string
     {
@@ -170,7 +177,6 @@ class MappingHelper
      * @param string $entityFqn
      *
      * @return string
-     * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public static function getTableNameForEntityFqn(
         string $entityFqn
@@ -207,7 +213,6 @@ class MappingHelper
      * @param ClassMetadataBuilder $builder
      * @param mixed                $default
      * @param bool                 $isUnique
-     * @SuppressWarnings(PHPMD.StaticAccess)
      * In this case the boolean argument is simply data
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
@@ -250,7 +255,6 @@ class MappingHelper
      * @param array                $fields
      * @param ClassMetadataBuilder $builder
      * @param mixed                $default
-     * @SuppressWarnings(PHPMD.StaticAccess)
      * In this case the boolean argument is simply data
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
@@ -287,7 +291,6 @@ class MappingHelper
      * @param array                $fields
      * @param ClassMetadataBuilder $builder
      * @param mixed                $default
-     * @SuppressWarnings(PHPMD.StaticAccess)
      * In this case the boolean argument is simply data
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
@@ -326,7 +329,6 @@ class MappingHelper
      * @param array                $fields
      * @param ClassMetadataBuilder $builder
      * @param mixed                $default
-     * @SuppressWarnings(PHPMD.StaticAccess)
      * In this case the boolean argument is simply data
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
@@ -365,7 +367,6 @@ class MappingHelper
      * @param array                $fields
      * @param ClassMetadataBuilder $builder
      * @param mixed                $default
-     * @SuppressWarnings(PHPMD.StaticAccess)
      * In this case the boolean argument is simply data
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
@@ -408,7 +409,6 @@ class MappingHelper
      * @param ClassMetadataBuilder $builder
      * @param mixed                $default
      * @param bool                 $isUnique
-     * @SuppressWarnings(PHPMD.StaticAccess)
      * In this case the boolean argument is simply data
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
@@ -447,7 +447,6 @@ class MappingHelper
      * @param array                $fields
      * @param ClassMetadataBuilder $builder
      * @param mixed                $default
-     * @SuppressWarnings(PHPMD.StaticAccess)
      * In this case the boolean argument is simply data
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
@@ -487,7 +486,6 @@ class MappingHelper
      *                                          'fieldName'=>'fieldSimpleType'
      *                                          ]
      * @param ClassMetadataBuilder $builder
-     * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public static function setSimpleFields(array $fieldToType, ClassMetadataBuilder $builder): void
     {

--- a/src/MappingHelper.php
+++ b/src/MappingHelper.php
@@ -155,6 +155,18 @@ class MappingHelper
     }
 
     /**
+     * Get the properly backticked and formatted column name for a field
+     *
+     * @param string $field
+     *
+     * @return string
+     */
+    public static function getColumnNameForField(string $field): string
+    {
+        return self::backticks(Inflector::tableize($field));
+    }
+
+    /**
      * @param string $entityFqn
      *
      * @return string
@@ -221,7 +233,7 @@ class MappingHelper
                 ]
             );
             $fieldBuilder
-                ->columnName(self::backticks(Inflector::tableize($field)))
+                ->columnName(self::getColumnNameForField($field))
                 ->nullable(null === $default)
                 ->unique($isUnique)
                 // see https://github.com/symfony/symfony-docs/issues/639
@@ -262,7 +274,7 @@ class MappingHelper
                     'default'   => $default,
                 ]
             );
-            $fieldBuilder->columnName(self::backticks(Inflector::tableize($field)))
+            $fieldBuilder->columnName(self::getColumnNameForField($field))
                          ->nullable(null === $default)
                          ->build();
         }
@@ -300,7 +312,7 @@ class MappingHelper
                 ]
             );
             $fieldBuilder
-                ->columnName(self::backticks(Inflector::tableize($field)))
+                ->columnName(self::getColumnNameForField($field))
                 ->nullable(null === $default)
                 ->precision(15)
                 ->scale(2)
@@ -339,7 +351,7 @@ class MappingHelper
                 ]
             );
             $fieldBuilder
-                ->columnName(self::backticks(Inflector::tableize($field)))
+                ->columnName(self::getColumnNameForField($field))
                 ->nullable(null === $default)
                 ->precision(18)
                 ->scale(12)
@@ -383,7 +395,7 @@ class MappingHelper
                 ]
             );
             $fieldBuilder
-                ->columnName(self::backticks(Inflector::tableize($field)))
+                ->columnName(self::getColumnNameForField($field))
                 ->nullable(null === $default)
                 ->build();
         }
@@ -422,7 +434,7 @@ class MappingHelper
                 ]
             );
             $fieldBuilder
-                ->columnName(self::backticks(Inflector::tableize($field)))
+                ->columnName(self::getColumnNameForField($field))
                 ->nullable(null === $default)
                 ->unique($isUnique)
                 ->build();
@@ -460,7 +472,7 @@ class MappingHelper
                 ]
             );
             $fieldBuilder
-                ->columnName(self::backticks(Inflector::tableize($field)))
+                ->columnName(self::getColumnNameForField($field))
                 ->nullable(null === $default)
                 ->build();
         }

--- a/src/MappingHelper.php
+++ b/src/MappingHelper.php
@@ -5,11 +5,17 @@ namespace EdmondsCommerce\DoctrineStaticMeta;
 use Doctrine\Common\Util\Inflector;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
+use Doctrine\ORM\Mapping\Builder\FieldBuilder;
 use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\NamespaceHelper;
 use EdmondsCommerce\DoctrineStaticMeta\Schema\Database;
 
 class MappingHelper
 {
+
+    /**
+     * @see https://stackoverflow.com/a/34275878
+     */
+    public const DATETIME_DEFAULT_CURRENT_TIME_STAMP = 0;
 
     /**
      * Quick accessors for common types that are supported by methods in this helper
@@ -187,7 +193,7 @@ class MappingHelper
      *
      * @param array                $fields
      * @param ClassMetadataBuilder $builder
-     * @param bool                 $isNullable
+     * @param mixed                $default
      * @param bool                 $isUnique
      * @SuppressWarnings(PHPMD.StaticAccess)
      * In this case the boolean argument is simply data
@@ -196,19 +202,30 @@ class MappingHelper
     public static function setSimpleStringFields(
         array $fields,
         ClassMetadataBuilder $builder,
-        bool $isNullable = true,
+        $default = null,
         bool $isUnique = false
     ): void {
+        if (null !== $default && !\is_string($default)) {
+            throw new \InvalidArgumentException('Invalid default value '.$default);
+        }
         foreach ($fields as $field) {
-            $builder->createField($field, Type::STRING)
-                    ->columnName(self::backticks(Inflector::tableize($field)))
-                    ->nullable($isNullable)
-                    ->unique($isUnique)
+            $fieldBuilder = new FieldBuilder(
+                $builder,
+                [
+                    'fieldName' => $field,
+                    'type'      => Type::STRING,
+                    'default'   => $default,
+                ]
+            );
+            $fieldBuilder
+                ->columnName(self::backticks(Inflector::tableize($field)))
+                ->nullable(null === $default)
+                ->unique($isUnique)
                 // see https://github.com/symfony/symfony-docs/issues/639
                 // basically, if we are using utf8mb4 then the max col
                 // length on strings is no longer 255.
-                    ->length(190)
-                    ->build();
+                ->length(190)
+                ->build();
         }
     }
 
@@ -217,7 +234,7 @@ class MappingHelper
      *
      * @param array                $fields
      * @param ClassMetadataBuilder $builder
-     * @param bool                 $isNullable
+     * @param mixed                $default
      * @SuppressWarnings(PHPMD.StaticAccess)
      * In this case the boolean argument is simply data
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
@@ -225,13 +242,23 @@ class MappingHelper
     public static function setSimpleTextFields(
         array $fields,
         ClassMetadataBuilder $builder,
-        bool $isNullable = true
+        $default = null
     ): void {
+        if (null !== $default && !\is_string($default)) {
+            throw new \InvalidArgumentException('Invalid default value '.$default);
+        }
         foreach ($fields as $field) {
-            $builder->createField($field, Type::TEXT)
-                    ->columnName(self::backticks(Inflector::tableize($field)))
-                    ->nullable($isNullable)
-                    ->build();
+            $fieldBuilder = new FieldBuilder(
+                $builder,
+                [
+                    'fieldName' => $field,
+                    'type'      => Type::TEXT,
+                    'default'   => $default,
+                ]
+            );
+            $fieldBuilder->columnName(self::backticks(Inflector::tableize($field)))
+                         ->nullable(null === $default)
+                         ->build();
         }
     }
 
@@ -241,7 +268,7 @@ class MappingHelper
      *
      * @param array                $fields
      * @param ClassMetadataBuilder $builder
-     * @param bool                 $isNullable
+     * @param mixed                $default
      * @SuppressWarnings(PHPMD.StaticAccess)
      * In this case the boolean argument is simply data
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
@@ -249,15 +276,26 @@ class MappingHelper
     public static function setSimpleFloatFields(
         array $fields,
         ClassMetadataBuilder $builder,
-        bool $isNullable = true
+        $default = null
     ): void {
+        if (null !== $default && !\is_float($default)) {
+            throw new \InvalidArgumentException('Invalid default value '.$default);
+        }
         foreach ($fields as $field) {
-            $builder->createField($field, Type::FLOAT)
-                    ->columnName(self::backticks(Inflector::tableize($field)))
-                    ->nullable($isNullable)
-                    ->precision(15)
-                    ->scale(2)
-                    ->build();
+            $fieldBuilder = new FieldBuilder(
+                $builder,
+                [
+                    'fieldName' => $field,
+                    'type'      => Type::FLOAT,
+                    'default'   => $default,
+                ]
+            );
+            $fieldBuilder
+                ->columnName(self::backticks(Inflector::tableize($field)))
+                ->nullable(null === $default)
+                ->precision(15)
+                ->scale(2)
+                ->build();
         }
     }
 
@@ -266,7 +304,7 @@ class MappingHelper
      *
      * @param array                $fields
      * @param ClassMetadataBuilder $builder
-     * @param bool                 $isNullable
+     * @param mixed                $default
      * @SuppressWarnings(PHPMD.StaticAccess)
      * In this case the boolean argument is simply data
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
@@ -274,15 +312,26 @@ class MappingHelper
     public static function setSimpleDecimalFields(
         array $fields,
         ClassMetadataBuilder $builder,
-        bool $isNullable = true
+        $default = null
     ): void {
+        if (null !== $default && !\is_float($default)) {
+            throw new \InvalidArgumentException('Invalid default value '.$default);
+        }
         foreach ($fields as $field) {
-            $builder->createField($field, Type::DECIMAL)
-                    ->columnName(self::backticks(Inflector::tableize($field)))
-                    ->nullable($isNullable)
-                    ->precision(18)
-                    ->scale(12)
-                    ->build();
+            $fieldBuilder = new FieldBuilder(
+                $builder,
+                [
+                    'fieldName' => $field,
+                    'type'      => Type::DECIMAL,
+                    'default'   => $default,
+                ]
+            );
+            $fieldBuilder
+                ->columnName(self::backticks(Inflector::tableize($field)))
+                ->nullable(null === $default)
+                ->precision(18)
+                ->scale(12)
+                ->build();
         }
     }
 
@@ -291,7 +340,7 @@ class MappingHelper
      *
      * @param array                $fields
      * @param ClassMetadataBuilder $builder
-     * @param bool                 $isNullable
+     * @param mixed                $default
      * @SuppressWarnings(PHPMD.StaticAccess)
      * In this case the boolean argument is simply data
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
@@ -299,13 +348,32 @@ class MappingHelper
     public static function setSimpleDatetimeFields(
         array $fields,
         ClassMetadataBuilder $builder,
-        bool $isNullable = true
+        $default = null
     ): void {
+        if (
+            null !== $default
+            && self::DATETIME_DEFAULT_CURRENT_TIME_STAMP !== $default
+        ) {
+            throw new \InvalidArgumentException(
+                'Invalid default '.$default
+                .' This must be one of:'
+                ."\n - null"
+                ."\n - \EdmondsCommerce\DoctrineStaticMeta\MappingHelper::DATETIME_DEFAULT_CURRENT_TIME_STAMP"
+            );
+        }
         foreach ($fields as $field) {
-            $builder->createField($field, Type::DATETIME)
-                    ->columnName(self::backticks(Inflector::tableize($field)))
-                    ->nullable($isNullable)
-                    ->build();
+            $fieldBuilder = new FieldBuilder(
+                $builder,
+                [
+                    'fieldName' => $field,
+                    'type'      => Type::DATETIME,
+                    'default'   => $default,
+                ]
+            );
+            $fieldBuilder
+                ->columnName(self::backticks(Inflector::tableize($field)))
+                ->nullable(null === $default)
+                ->build();
         }
     }
 
@@ -314,7 +382,7 @@ class MappingHelper
      *
      * @param array                $fields
      * @param ClassMetadataBuilder $builder
-     * @param bool                 $isNullable
+     * @param mixed                $default
      * @param bool                 $isUnique
      * @SuppressWarnings(PHPMD.StaticAccess)
      * In this case the boolean argument is simply data
@@ -323,15 +391,26 @@ class MappingHelper
     public static function setSimpleIntegerFields(
         array $fields,
         ClassMetadataBuilder $builder,
-        bool $isNullable = true,
+        $default = null,
         bool $isUnique = false
     ): void {
+        if (null !== $default && !\is_int($default)) {
+            throw new \InvalidArgumentException('Invalid default value '.$default);
+        }
         foreach ($fields as $field) {
-            $builder->createField($field, Type::INTEGER)
-                    ->columnName(self::backticks(Inflector::tableize($field)))
-                    ->nullable($isNullable)
-                    ->unique($isUnique)
-                    ->build();
+            $fieldBuilder = new FieldBuilder(
+                $builder,
+                [
+                    'fieldName' => $field,
+                    'type'      => Type::INTEGER,
+                    'default'   => $default,
+                ]
+            );
+            $fieldBuilder
+                ->columnName(self::backticks(Inflector::tableize($field)))
+                ->nullable(null === $default)
+                ->unique($isUnique)
+                ->build();
         }
     }
 
@@ -340,7 +419,7 @@ class MappingHelper
      *
      * @param array                $fields
      * @param ClassMetadataBuilder $builder
-     * @param bool                 $isNullable
+     * @param mixed                $default
      * @SuppressWarnings(PHPMD.StaticAccess)
      * In this case the boolean argument is simply data
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
@@ -348,13 +427,24 @@ class MappingHelper
     public static function setSimpleBooleanFields(
         array $fields,
         ClassMetadataBuilder $builder,
-        bool $isNullable = true
+        $default = null
     ): void {
+        if (null !== $default && !\is_bool($default)) {
+            throw new \InvalidArgumentException('Invalid default value '.$default);
+        }
         foreach ($fields as $field) {
-            $builder->createField($field, Type::BOOLEAN)
-                    ->columnName(self::backticks(Inflector::tableize($field)))
-                    ->nullable($isNullable)
-                    ->build();
+            $fieldBuilder = new FieldBuilder(
+                $builder,
+                [
+                    'fieldName' => $field,
+                    'type'      => Type::BOOLEAN,
+                    'default'   => $default,
+                ]
+            );
+            $fieldBuilder
+                ->columnName(self::backticks(Inflector::tableize($field)))
+                ->nullable(null === $default)
+                ->build();
         }
     }
 

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -10,6 +10,7 @@ use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\AbstractGenerato
 use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\EntityGenerator;
 use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\FieldGenerator;
 use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\RelationsGenerator;
+use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\NamespaceHelper;
 use EdmondsCommerce\DoctrineStaticMeta\GeneratedCode\GeneratedCodeTest;
 use EdmondsCommerce\DoctrineStaticMeta\Schema\Database;
 use EdmondsCommerce\DoctrineStaticMeta\Schema\Schema;
@@ -133,10 +134,13 @@ abstract class AbstractTest extends TestCase
      * @param string $extra
      *
      * @return string
+     * @throws Exception\DoctrineStaticMetaException
      */
     protected function getCopiedFqn(string $fqn, string $extra = 'Copied'): string
     {
-        return '\\'.$extra.ltrim($fqn, '\\');
+        return $this->container
+            ->get(NamespaceHelper::class)
+            ->tidy('\\'.$extra.ltrim($fqn, '\\'));
     }
 
     /**
@@ -162,8 +166,7 @@ abstract class AbstractTest extends TestCase
         $testConfig[ConfigInterface::PARAM_DB_NAME]       .= '_test';
         $testConfig[ConfigInterface::PARAM_DEVMODE]       = true;
         $this->container                                  = new Container();
-        $this->container->buildSymfonyContainer($testConfig);
-        $this->container->get(Database::class)->drop(true)->create(true);
+        $this->container->buildSymfonyContainer($testConfig, false);
     }
 
 

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -166,7 +166,7 @@ abstract class AbstractTest extends TestCase
         $testConfig[ConfigInterface::PARAM_DB_NAME]       .= '_test';
         $testConfig[ConfigInterface::PARAM_DEVMODE]       = true;
         $this->container                                  = new Container();
-        $this->container->buildSymfonyContainer($testConfig, false);
+        $this->container->buildSymfonyContainer($testConfig);
     }
 
 

--- a/tests/CodeGeneration/CodeHelperTest.php
+++ b/tests/CodeGeneration/CodeHelperTest.php
@@ -2,12 +2,10 @@
 
 namespace EdmondsCommerce\DoctrineStaticMeta\CodeGeneration;
 
-use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use PHPUnit\Framework\TestCase;
 
-class CodeHelperTest extends AbstractTest
+class CodeHelperTest extends TestCase
 {
-
-    public const WORK_DIR = AbstractTest::VAR_PATH.'/CodeHelperTest';
 
     /**
      * @var CodeHelper
@@ -16,8 +14,21 @@ class CodeHelperTest extends AbstractTest
 
     public function setup()
     {
-        parent::setup();
-        $this->helper = $this->container->get(CodeHelper::class);
+        $this->helper = new CodeHelper(new NamespaceHelper());
+    }
+
+    public function testGetTypeWorksAsExpected()
+    {
+        $expectedTypesToVars = [
+            'string' => 'string',
+            'float'  => 1.01,
+            'int'    => 2,
+            'bool'   => true,
+            'null'   => null,
+        ];
+        foreach ($expectedTypesToVars as $expected => $var) {
+            $this->assertEquals($expected, $this->helper->getType($var));
+        }
     }
 
     public function testfixSuppressWarningsTags()
@@ -141,7 +152,7 @@ class Address implements
 }
 
 PHP;
-        $expected = <<<PHP
+        $expected  = <<<PHP
 <?php
 declare(strict_types=1);
 
@@ -174,7 +185,7 @@ class Address implements
 
 PHP;
         // phpcs:enable
-        $actual   = $this->helper->phpcsIgnoreUseSection($generated);
+        $actual = $this->helper->phpcsIgnoreUseSection($generated);
         $this->assertEquals($expected, $actual);
     }
 
@@ -183,7 +194,7 @@ PHP;
      */
     public function itWillReturnAnIsMethodForABooleanField(): void
     {
-        $fieldName = 'testField';
+        $fieldName  = 'testField';
         $methodName = $this->helper->getGetterMethodNameForBoolean($fieldName);
         $this->assertEquals('isTestField', $methodName);
     }
@@ -193,7 +204,7 @@ PHP;
      */
     public function itWillNotReturnIsTwice(): void
     {
-        $fieldName = 'isReadOnly';
+        $fieldName  = 'isReadOnly';
         $methodName = $this->helper->getGetterMethodNameForBoolean($fieldName);
         $this->assertEquals($fieldName, $methodName);
     }
@@ -203,7 +214,7 @@ PHP;
      */
     public function itWillNotReturnIsHasInTheMEthodName(): void
     {
-        $fieldName = 'hasHeaders';
+        $fieldName  = 'hasHeaders';
         $methodName = $this->helper->getGetterMethodNameForBoolean($fieldName);
         $this->assertEquals($fieldName, $methodName);
     }

--- a/tests/CodeGeneration/CodeHelperTest.php
+++ b/tests/CodeGeneration/CodeHelperTest.php
@@ -27,7 +27,7 @@ class CodeHelperTest extends TestCase
             'null'   => null,
         ];
         foreach ($expectedTypesToVars as $expected => $var) {
-            $this->assertEquals($expected, $this->helper->getType($var));
+            $this->assertSame($expected, $this->helper->getType($var));
         }
     }
 
@@ -36,7 +36,7 @@ class CodeHelperTest extends TestCase
         $generated = '@SuppressWarnings (Something)';
         $expected  = '@SuppressWarnings(Something)';
         $actual    = $this->helper->fixSuppressWarningsTags($generated);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function testMakeConstsPublic()
@@ -44,7 +44,7 @@ class CodeHelperTest extends TestCase
         $generated = '    const THIS="that"';
         $expected  = '    public const THIS="that"';
         $actual    = $this->helper->makeConstsPublic($generated);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -77,7 +77,7 @@ class Address implements
 }
 ';
         $actual   = $this->helper->breakImplementsOntoLines($generated);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function testConstArraysOnMultipleLines()
@@ -116,7 +116,7 @@ class Address
 }
 PHP;
         $actual   = $this->helper->constArraysOnMultipleLines($generated);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function testPhpcsIgnoreUseSection()
@@ -186,7 +186,7 @@ class Address implements
 PHP;
         // phpcs:enable
         $actual = $this->helper->phpcsIgnoreUseSection($generated);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -196,7 +196,7 @@ PHP;
     {
         $fieldName  = 'testField';
         $methodName = $this->helper->getGetterMethodNameForBoolean($fieldName);
-        $this->assertEquals('isTestField', $methodName);
+        $this->assertSame('isTestField', $methodName);
     }
 
     /**
@@ -206,7 +206,7 @@ PHP;
     {
         $fieldName  = 'isReadOnly';
         $methodName = $this->helper->getGetterMethodNameForBoolean($fieldName);
-        $this->assertEquals($fieldName, $methodName);
+        $this->assertSame($fieldName, $methodName);
     }
 
     /**
@@ -216,6 +216,6 @@ PHP;
     {
         $fieldName  = 'hasHeaders';
         $methodName = $this->helper->getGetterMethodNameForBoolean($fieldName);
-        $this->assertEquals($fieldName, $methodName);
+        $this->assertSame($fieldName, $methodName);
     }
 }

--- a/tests/CodeGeneration/CodeHelperTest.php
+++ b/tests/CodeGeneration/CodeHelperTest.php
@@ -17,19 +17,6 @@ class CodeHelperTest extends TestCase
         $this->helper = new CodeHelper(new NamespaceHelper());
     }
 
-    public function testGetTypeWorksAsExpected()
-    {
-        $expectedTypesToVars = [
-            'string' => 'string',
-            'float'  => 1.01,
-            'int'    => 2,
-            'bool'   => true,
-            'null'   => null,
-        ];
-        foreach ($expectedTypesToVars as $expected => $var) {
-            $this->assertSame($expected, $this->helper->getType($var));
-        }
-    }
 
     public function testfixSuppressWarningsTags()
     {

--- a/tests/CodeGeneration/CodeHelperTest.php
+++ b/tests/CodeGeneration/CodeHelperTest.php
@@ -177,4 +177,34 @@ PHP;
         $actual   = $this->helper->phpcsIgnoreUseSection($generated);
         $this->assertEquals($expected, $actual);
     }
+
+    /**
+     * @test
+     */
+    public function itWillReturnAnIsMethodForABooleanField(): void
+    {
+        $fieldName = 'testField';
+        $methodName = $this->helper->getGetterMethodNameForBoolean($fieldName);
+        $this->assertEquals('isTestField', $methodName);
+    }
+
+    /**
+     * @test
+     */
+    public function itWillNotReturnIsTwice(): void
+    {
+        $fieldName = 'isReadOnly';
+        $methodName = $this->helper->getGetterMethodNameForBoolean($fieldName);
+        $this->assertEquals($fieldName, $methodName);
+    }
+
+    /**
+     * @test
+     */
+    public function itWillNotReturnIsHasInTheMEthodName(): void
+    {
+        $fieldName = 'hasHeaders';
+        $methodName = $this->helper->getGetterMethodNameForBoolean($fieldName);
+        $this->assertEquals($fieldName, $methodName);
+    }
 }

--- a/tests/CodeGeneration/Generator/FieldGeneratorTest.php
+++ b/tests/CodeGeneration/Generator/FieldGeneratorTest.php
@@ -138,7 +138,7 @@ class FieldGeneratorTest extends AbstractTest
                 }
             }
         }
-        $this->assertEquals([], $errors, print_r($errors, true));
+        $this->assertSame([], $errors, print_r($errors, true));
     }
 
     /**

--- a/tests/CodeGeneration/Generator/FieldGeneratorTest.php
+++ b/tests/CodeGeneration/Generator/FieldGeneratorTest.php
@@ -50,7 +50,7 @@ class FieldGeneratorTest extends AbstractTest
             '\\Blah\\Foop',
             MappingHelper::TYPE_STRING,
             null,
-            true,
+            null,
             true
         );
     }
@@ -62,7 +62,7 @@ class FieldGeneratorTest extends AbstractTest
             '\\Blah\\Foop',
             'invalid',
             null,
-            true,
+            null,
             true
         );
     }
@@ -74,7 +74,19 @@ class FieldGeneratorTest extends AbstractTest
             '\\Blah\\Foop',
             MappingHelper::PHP_TYPE_FLOAT,
             'invalid',
-            true,
+            null,
+            true
+        );
+    }
+
+    public function testDefaultTypeMustBeValid()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->fieldGenerator->generateField(
+            '\\Blah\\Foop',
+            MappingHelper::PHP_TYPE_FLOAT,
+            'invalid',
+            'clearly not a float',
             true
         );
     }
@@ -85,8 +97,7 @@ class FieldGeneratorTest extends AbstractTest
      * @param string $name
      * @param string $type
      *
-     * @param bool   $isNullable
-     *
+     * @param mixed  $default
      * @param bool   $isUnique
      *
      * @return string
@@ -97,14 +108,14 @@ class FieldGeneratorTest extends AbstractTest
     protected function buildAndCheck(
         string $name,
         string $type,
-        bool $isNullable = true,
+        $default = null,
         bool $isUnique = false
     ): string {
         $fieldTraitFqn = $this->fieldGenerator->generateField(
             $name,
             $type,
             null,
-            $isNullable,
+            $default,
             $isUnique
         );
 
@@ -143,7 +154,7 @@ class FieldGeneratorTest extends AbstractTest
     {
         $this->getEntityGenerator()->generateEntity(self::TEST_ENTITY_CAR);
         foreach (self::CAR_FIELDS_TO_TYPES as $args) {
-            $fieldFqn = $this->buildAndCheck($args[0], $args[1], false);
+            $fieldFqn = $this->buildAndCheck($args[0], $args[1], null);
             $this->fieldGenerator->setEntityHasField(self::TEST_ENTITY_CAR, $fieldFqn);
         }
         $this->qaGeneratedCode();
@@ -153,7 +164,7 @@ class FieldGeneratorTest extends AbstractTest
     {
         $this->getEntityGenerator()->generateEntity(self::TEST_ENTITY_CAR);
         foreach (self::CAR_FIELDS_TO_TYPES as $args) {
-            $fieldFqn = $this->buildAndCheck($args[0], $args[1], true);
+            $fieldFqn = $this->buildAndCheck($args[0], $args[1], null);
             $this->fieldGenerator->setEntityHasField(self::TEST_ENTITY_CAR, $fieldFqn);
         }
         $this->qaGeneratedCode();
@@ -163,7 +174,7 @@ class FieldGeneratorTest extends AbstractTest
     {
         $this->getEntityGenerator()->generateEntity(self::TEST_ENTITY_CAR);
         foreach (self::UNIQUE_FIELDS_TO_TYPES as $args) {
-            $fieldFqn = $this->buildAndCheck($args[0], $args[1], true, true);
+            $fieldFqn = $this->buildAndCheck($args[0], $args[1], null, true);
             $this->fieldGenerator->setEntityHasField(self::TEST_ENTITY_CAR, $fieldFqn);
         }
         $this->qaGeneratedCode();

--- a/tests/CodeGeneration/Generator/FieldGeneratorTest.php
+++ b/tests/CodeGeneration/Generator/FieldGeneratorTest.php
@@ -92,9 +92,7 @@ class FieldGeneratorTest extends AbstractTest
     }
 
     /**
-     * Default values passed in by CLI could come through quite dirty and need to be normalised
-     *
-     * @throws \EdmondsCommerce\DoctrineStaticMeta\Exception\DoctrineStaticMetaException
+     * Default values passed in by CLI could come through quite dirty and need to be normalised     *
      */
     public function testDefaultValueIsNormalised()
     {
@@ -190,6 +188,14 @@ class FieldGeneratorTest extends AbstractTest
             $this->assertNotContains('(string', $interfaceContents);
             $this->assertNotContains(': string', $traitContents);
             $this->assertNotContains('(string', $traitContents);
+            $phpType = MappingHelper::COMMON_TYPES_TO_PHP_TYPES[$type];
+            if (null === $default) {
+                $phpType = "?$phpType";
+            }
+            $this->assertContains(': '.$phpType, $interfaceContents);
+            $this->assertContains('('.$phpType, $interfaceContents);
+            $this->assertContains(': '.$phpType, $traitContents);
+            $this->assertContains('('.$phpType, $traitContents);
         }
 
         if ($type === MappingHelper::TYPE_BOOLEAN) {

--- a/tests/CodeGeneration/Generator/RelationsGeneratorTest.php
+++ b/tests/CodeGeneration/Generator/RelationsGeneratorTest.php
@@ -89,7 +89,7 @@ class RelationsGeneratorTest extends AbstractTest
 
             return array_merge(array_diff($arrayX, $intersect), array_diff($arrayY, $intersect));
         };
-        $this->assertEquals(
+        $this->assertSame(
             $hasTypesCounted,
             $hasTypesDefinedInConstantArray,
             'The number of defined in the constant array RelationsGenerator::HAS_TYPES is not correct:'

--- a/tests/CodeGeneration/NamespaceHelperTest.php
+++ b/tests/CodeGeneration/NamespaceHelperTest.php
@@ -127,7 +127,7 @@ PHP
             'No\\Changes\\Required'             => 'No\\Changes\\Required',
         ];
         foreach ($namespaceToExpected as $namespace => $expected) {
-            $this->assertEquals($expected, $this->helper->tidy($namespace));
+            $this->assertSame($expected, $this->helper->tidy($namespace));
         }
     }
 
@@ -138,7 +138,7 @@ PHP
             'No\\Changes\\Required'               => 'No\\Changes\\Required',
         ];
         foreach ($namespaceToExpected as $namespace => $expected) {
-            $this->assertEquals($expected, $this->helper->root($namespace));
+            $this->assertSame($expected, $this->helper->root($namespace));
         }
     }
 
@@ -150,14 +150,14 @@ PHP
 
         $expected = self::TEST_PROJECT_ROOT_NAMESPACE;
         $actual   = $this->helper->getProjectNamespaceRootFromEntityFqn($entity1Fqn);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $entityFqnWithEntitiesInProjectName = self::TEST_ENTITY_WITH_ENTITIES_IN_PROJECT_NAME;
         $expected                           = '\\My\\EntitiesProject';
         $actual                             = $this->helper->getProjectNamespaceRootFromEntityFqn(
             $entityFqnWithEntitiesInProjectName
         );
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -182,7 +182,7 @@ PHP
             $srcOrTestSubFolder,
             $projectRootNamespace
         );
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $entity1Fqn           = '\\'.self::TEST_ENTITIES[0];
         $srcOrTestSubFolder   = 'src';
@@ -201,7 +201,7 @@ PHP
             $srcOrTestSubFolder,
             $projectRootNamespace
         );
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -221,7 +221,7 @@ PHP
             $projectRootNamespace
         );
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -231,22 +231,22 @@ PHP
         $entityFqn = self::TEST_ENTITIES[0];
         $expected  = 'Blah\\Foo';
         $actual    = $this->helper->getEntitySubNamespace($entityFqn);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $entityFqn = '\\My\\Test\\Project\\Entities\\No\\Relatives';
         $expected  = 'No\\Relatives';
         $actual    = $this->helper->getEntitySubNamespace($entityFqn);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $entityFqn = '\\My\\Test\\Project\\Entities\\Person';
         $expected  = 'Person';
         $actual    = $this->helper->getEntitySubNamespace($entityFqn);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $entityFqn = '\\My\\Test\\EntitiesProject\\Entities\\Person';
         $expected  = 'Person';
         $actual    = $this->helper->getEntitySubNamespace($entityFqn);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -256,12 +256,12 @@ PHP
         $entityFqn = '\\My\\Test\\Project\\Entities\\Person';
         $expected  = '/Person.php';
         $actual    = $this->helper->getEntityFileSubPath($entityFqn);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $entityFqn = self::TEST_ENTITY_WITH_ENTITIES_IN_PROJECT_NAME;
         $expected  = '/Blah/Foo.php';
         $actual    = $this->helper->getEntityFileSubPath($entityFqn);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -271,12 +271,12 @@ PHP
         $entityFqn = self::TEST_ENTITIES[0];
         $expected  = '/Blah/Foo';
         $actual    = $this->helper->getEntitySubPath($entityFqn);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $entityFqn = self::TEST_ENTITY_WITH_ENTITIES_IN_PROJECT_NAME;
         $expected  = '/Blah/Foo';
         $actual    = $this->helper->getEntitySubPath($entityFqn);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -288,7 +288,7 @@ PHP
                                         .AbstractGenerator::ENTITY_RELATIONS_NAMESPACE;
         $expected                     = $entityRelationsRootNamespace.'\\Blah\\Foo\\Interfaces';
         $actual                       = $this->helper->getInterfacesNamespaceForEntity($entityFqn);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -300,7 +300,7 @@ PHP
                                         .AbstractGenerator::ENTITY_RELATIONS_NAMESPACE;
         $expected                     = $entityRelationsRootNamespace.'\\Blah\\Foo\\Traits';
         $actual                       = $this->helper->getTraitsNamespaceForEntity($entityFqn);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -312,13 +312,13 @@ PHP
         $entityReflection = new \ReflectionClass(self::TEST_ENTITY_POST_CREATED);
         $expected         = self::TEST_PROJECT_ROOT_NAMESPACE.'\\'.AbstractGenerator::ENTITIES_FOLDER_NAME;
         $actual           = $this->helper->getEntityNamespaceRootFromEntityReflection($entityReflection);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $entityFqn = '\\My\\Test\\Project\\Entities\\No\\Relative';
         $actual    = $this->helper->getEntityNamespaceRootFromEntityReflection(
             new \ReflectionClass($entityFqn)
         );
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -330,14 +330,14 @@ PHP
                      .AbstractGenerator::ENTITY_RELATIONS_NAMESPACE
                      .'\\Meh\\Interfaces\\HasMehsInterface';
         $actual    = $this->helper->getHasPluralInterfaceFqnForEntity($entityFqn);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $entityFqn = self::TEST_ENTITY_POST_CREATED_NESTED;
         $expected  = self::TEST_PROJECT_ROOT_NAMESPACE
                      .AbstractGenerator::ENTITY_RELATIONS_NAMESPACE
                      .'\\Nested\\Something\\Ho\\Hum\\Interfaces\\HasNestedSomethingHoHumsInterface';
         $actual    = $this->helper->getHasPluralInterfaceFqnForEntity($entityFqn);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -349,14 +349,14 @@ PHP
                      .AbstractGenerator::ENTITY_RELATIONS_NAMESPACE
                      .'\\Meh\\Interfaces\\HasMehInterface';
         $actual    = $this->helper->getHasSingularInterfaceFqnForEntity($entityFqn);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $entityFqn = self::TEST_ENTITY_POST_CREATED_NESTED;
         $expected  = self::TEST_PROJECT_ROOT_NAMESPACE
                      .AbstractGenerator::ENTITY_RELATIONS_NAMESPACE
                      .'\\Nested\\Something\\Ho\\Hum\\Interfaces\\HasNestedSomethingHoHumInterface';
         $actual    = $this->helper->getHasSingularInterfaceFqnForEntity($entityFqn);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -366,7 +366,7 @@ PHP
     {
         $expected = 'EdmondsCommerce\\DoctrineStaticMeta';
         $actual   = $this->helper->getProjectRootNamespaceFromComposerJson();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -388,7 +388,7 @@ PHP
         foreach (RelationsGenerator::HAS_TYPES as $hasType) {
             $actual[$hasType] = $this->helper->stripPrefixFromHasType($hasType);
         }
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
         foreach ($actual as $hasType => $stripped) {
             $ownedHasName    = $this->helper->getOwnedHasName(
                 $hasType,
@@ -437,7 +437,7 @@ PHP
                 "\\TemplateNamespace"
             );
         }
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $actual,
             "\nExpected:\n".var_export($actual, true)
@@ -469,7 +469,7 @@ PHP
                 "\\TemplateNamespace"
             );
         }
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $actual,
             "\nExpected:\n".var_export($actual, true)

--- a/tests/CodeGeneration/TypeHelperTest.php
+++ b/tests/CodeGeneration/TypeHelperTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\CodeGeneration;
+
+use EdmondsCommerce\DoctrineStaticMeta\MappingHelper;
+use PHPUnit\Framework\TestCase;
+
+class TypeHelperTest extends TestCase
+{
+    /**
+     * @var TypeHelper
+     */
+    private $helper;
+
+    public function setup()
+    {
+        $this->helper = new TypeHelper();
+    }
+
+    public function testGetTypeWorksAsExpected()
+    {
+        $expectedTypesToVars = [
+            'string' => 'string',
+            'float'  => 1.01,
+            'int'    => 2,
+            'bool'   => true,
+            'null'   => null,
+        ];
+        foreach ($expectedTypesToVars as $expected => $var) {
+            $this->assertSame($expected, $this->helper->getType($var));
+        }
+    }
+
+    public function testTypeNormaliserWorksAsExpected()
+    {
+        $defaultValuesToTypes = [
+            MappingHelper::PHP_TYPE_INTEGER => [
+                [1, 1],
+                ['1', 1],
+                [' 1', 1],
+                [' 1 ', 1],
+            ],
+            MappingHelper::PHP_TYPE_FLOAT   => [
+                [1, 1.0],
+                [1.0, 1.0],
+                ['1', 1.0],
+                ['1.1', 1.1],
+                [' 1.1 ', 1.1],
+                [' 1.1 ', 1.1],
+            ],
+            MappingHelper::PHP_TYPE_BOOLEAN => [
+                ['true', true],
+                ['false', false],
+                ['TRUE', true],
+                ['FALSE', false],
+                [' TRue ', true],
+                [' FaLse ', false],
+            ],
+        ];
+
+        foreach ($defaultValuesToTypes as $type => $valueAndExpecteds) {
+            foreach ($valueAndExpecteds as $valueAndExpected) {
+                list($value, $expected) = $valueAndExpected;
+                $normalised = $this->helper->normaliseValueToType($value, $type);
+                $this->assertSame($expected, $normalised);
+            }
+        }
+    }
+
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -31,7 +31,7 @@ class ConfigTest extends TestCase
         $config   = new Config(self::SERVER);
         $expected = self::SERVER[ConfigInterface::PARAM_DB_NAME];
         $actual   = $config->get(ConfigInterface::PARAM_DB_NAME);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function testGetDefaultParam()
@@ -39,7 +39,7 @@ class ConfigTest extends TestCase
         $config   = new Config(self::SERVER);
         $expected = ConfigInterface::OPTIONAL_PARAMS_WITH_DEFAULTS[ConfigInterface::PARAM_DB_DEBUG];
         $actual   = $config->get(ConfigInterface::PARAM_DB_DEBUG);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function testGetProjectRootDirectory()
@@ -47,7 +47,7 @@ class ConfigTest extends TestCase
         $config   = new Config(self::SERVER);
         $expected = realpath(__DIR__.'/../');
         $actual   = $config::getProjectRootDirectory();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function testGetCalculatedDefaultParam()
@@ -55,7 +55,7 @@ class ConfigTest extends TestCase
         $config   = new Config(self::SERVER);
         $expected = realpath(__DIR__.'/../').'/src/Entities';
         $actual   = $config->get(ConfigInterface::PARAM_ENTITIES_PATH);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function testGetConfiguredNotDefaultParam()
@@ -65,7 +65,7 @@ class ConfigTest extends TestCase
         $config                                       = new Config($server);
         $expected                                     = $server[ConfigInterface::PARAM_ENTITIES_PATH];
         $actual                                       = $config->get(ConfigInterface::PARAM_ENTITIES_PATH);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function testParamsContainsAll()
@@ -77,6 +77,6 @@ class ConfigTest extends TestCase
             ConfigInterface::OPTIONAL_PARAMS_WITH_DEFAULTS
         );
         $countAggregated = count($aggregated);
-        $this->assertEquals($countAggregated, $countParams);
+        $this->assertSame($countAggregated, $countParams);
     }
 }

--- a/tests/Entity/Fields/Traits/AbstractFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/AbstractFieldTraitTest.php
@@ -31,6 +31,9 @@ abstract class AbstractFieldTraitTest extends AbstractTest
      */
     protected static $fakerGenerator;
 
+    /**
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     */
     public static function setUpBeforeClass(
     )/* The :void return type declaration that should be here would cause a BC issue */
     {

--- a/tests/Entity/Fields/Traits/AbstractFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/AbstractFieldTraitTest.php
@@ -1,0 +1,131 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\AbstractGenerator;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\FakerData\FakerDataProviderInterface;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces\EntityInterface;
+use Faker\Generator;
+
+abstract class AbstractFieldTraitTest extends AbstractTest
+{
+    protected const TEST_ENTITY_FQN = AbstractTest::TEST_PROJECT_ROOT_NAMESPACE
+                                      .'\\'.AbstractGenerator::ENTITIES_FOLDER_NAME
+                                      .'\\TestEntity';
+
+    protected const TEST_FIELD_FQN = 'Override Me';
+
+    protected const TEST_FIELD_PROP = 'Override Me';
+
+    /**
+     * @var Generator
+     */
+    protected static $fakerGenerator;
+
+    public static function setUpBeforeClass(
+    )/* The :void return type declaration that should be here would cause a BC issue */
+    {
+        self::$fakerGenerator = \Faker\Factory::create();
+    }
+
+    public function setup()
+    {
+        parent::setup();
+        $this->getEntityGenerator()->generateEntity(static::TEST_ENTITY_FQN);
+        $this->getFieldGenerator()->setEntityHasField(static::TEST_ENTITY_FQN, static::TEST_FIELD_FQN);
+        $this->setupCopiedWorkDir();
+    }
+
+    /**
+     * @param EntityInterface $entity
+     *
+     * @return string
+     * @throws \Exception
+     */
+    protected function getGetter(EntityInterface $entity): string
+    {
+        foreach (['get', 'is'] as $prefix) {
+            $method = $prefix.static::TEST_FIELD_PROP;
+            if (\method_exists($entity, $method)) {
+                return $method;
+            }
+        }
+        throw new \RuntimeException('Failed finding a getter in '.__METHOD__);
+    }
+
+    protected function findFakerProvider(): ?FakerDataProviderInterface
+    {
+        $fakerProviderFqnBase = 'EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\FakerData';
+        $traitBase            = 'EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits';
+        $fakerFqn             = \str_replace(
+            [
+                $traitBase,
+                'FieldTrait',
+            ],
+            [
+                $fakerProviderFqnBase,
+                'FakerData',
+            ],
+            static::TEST_FIELD_FQN
+        );
+        if (class_exists($fakerFqn)) {
+            return new $fakerFqn(self::$fakerGenerator);
+        }
+    }
+
+    /**
+     * @param EntityInterface $entity
+     *
+     * @return mixed
+     * @throws \ReflectionException
+     */
+    protected function setFakerValueForProperty(EntityInterface $entity)
+    {
+        $setter        = 'set'.static::TEST_FIELD_PROP;
+        $fakerProvider = $this->findFakerProvider();
+        if ($fakerProvider instanceof FakerDataProviderInterface) {
+            $setValue = $fakerProvider();
+            $entity->$setter($setValue);
+
+            return $setValue;
+        }
+        $reflection       = new \ReflectionClass($entity);
+        $setterReflection = $reflection->getMethod($setter);
+        $setParamType     = current($setterReflection->getParameters())->getType();
+        switch ($setParamType) {
+            case 'string':
+                $setValue = $entity->$setter(self::$fakerGenerator->text());
+                break;
+            case 'int':
+            case 'float':
+                $setValue = $entity->$setter(self::$fakerGenerator->numberBetween(0, 100));
+                break;
+            case 'bool':
+                $setValue = $entity->$setter(self::$fakerGenerator->boolean);
+                break;
+            default:
+                throw new \RuntimeException('Failed getting a data provider for the property type '.$setParamType);
+        }
+        $entity->$setter($setValue);
+
+        return $setValue;
+    }
+
+
+    /**
+     * @throws \EdmondsCommerce\DoctrineStaticMeta\Exception\DoctrineStaticMetaException
+     * @throws \ReflectionException
+     */
+    public function testCreateEntityWithField()
+    {
+        $entityFqn = $this->getCopiedFqn(static::TEST_ENTITY_FQN);
+        $entity    = new $entityFqn();
+        $getter    = $this->getGetter($entity);
+        $this->assertTrue(\method_exists($entity, $getter));
+        $value = $entity->$getter();
+        $this->assertEmpty($value);
+        $setValue = $this->setFakerValueForProperty($entity);
+        $this->assertEquals($setValue, $entity->$getter());
+    }
+}

--- a/tests/Entity/Fields/Traits/AbstractFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/AbstractFieldTraitTest.php
@@ -16,6 +16,12 @@ abstract class AbstractFieldTraitTest extends AbstractTest
 
     protected const TEST_FIELD_FQN = 'Override Me';
 
+    /**
+     * The expected default value for the field. Most fields are marked as nullable so the default is null.
+     * Should be overriden in the actual field test for any fields that are not nullable
+     */
+    protected const TEST_FIELD_DEFAULT = null;
+
     protected const TEST_FIELD_PROP = 'Override Me';
 
     protected $entitySuffix;
@@ -142,8 +148,8 @@ abstract class AbstractFieldTraitTest extends AbstractTest
         $getter    = $this->getGetter($entity);
         $this->assertTrue(\method_exists($entity, $getter));
         $value = $entity->$getter();
-        $this->assertEmpty($value);
+        $this->assertSame(static::TEST_FIELD_DEFAULT, $value);
         $setValue = $this->setFakerValueForProperty($entity);
-        $this->assertEquals($setValue, $entity->$getter());
+        $this->assertSame($setValue, $entity->$getter());
     }
 }

--- a/tests/Entity/Fields/Traits/AbstractFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/AbstractFieldTraitTest.php
@@ -117,7 +117,7 @@ abstract class AbstractFieldTraitTest extends AbstractTest
      * @throws \EdmondsCommerce\DoctrineStaticMeta\Exception\DoctrineStaticMetaException
      * @throws \ReflectionException
      */
-    public function testCreateEntityWithField()
+    public function testCreateEntityWithField(): void
     {
         $entityFqn = $this->getCopiedFqn(static::TEST_ENTITY_FQN);
         $entity    = new $entityFqn();

--- a/tests/Entity/Fields/Traits/AbstractFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/AbstractFieldTraitTest.php
@@ -35,6 +35,11 @@ abstract class AbstractFieldTraitTest extends AbstractTest
     {
         parent::setup();
         $this->entitySuffix = substr(static::class, strrpos(static::class, '\\') + 1);
+        $this->generateCode();
+    }
+
+    protected function generateCode()
+    {
         $this->getEntityGenerator()
              ->generateEntity(static::TEST_ENTITY_FQN_BASE.$this->entitySuffix);
         $this->getFieldGenerator()

--- a/tests/Entity/Fields/Traits/Attribute/IpAddressFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/Attribute/IpAddressFieldTraitTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Attribute;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Attribute\IpAddressFieldInterface;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
+
+class IpAddressFieldTraitTest extends AbstractFieldTraitTest
+{
+    public const    WORK_DIR        = AbstractTest::VAR_PATH.'/IpAddressFieldTraitTest/';
+    protected const TEST_FIELD_FQN  = IpAddressFieldTrait::class;
+    protected const TEST_FIELD_PROP = IpAddressFieldInterface::PROP_IP_ADDRESS;
+}

--- a/tests/Entity/Fields/Traits/Attribute/LabelFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/Attribute/LabelFieldTraitTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Attribute;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Attribute\LabelFieldInterface; 
+
+class LabelFieldTraitTest extends AbstractFieldTraitTest
+{
+    public const WORK_DIR = AbstractTest::VAR_PATH.'/LabelFieldTraitTest/';
+    protected const TEST_FIELD_FQN =   LabelFieldTrait::class;
+    protected const TEST_FIELD_PROP =  LabelFieldInterface::PROP_LABEL;
+}

--- a/tests/Entity/Fields/Traits/Attribute/NameFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/Attribute/NameFieldTraitTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Attribute;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Attribute\NameFieldInterface; 
+
+class NameFieldTraitTest extends AbstractFieldTraitTest
+{
+    public const WORK_DIR = AbstractTest::VAR_PATH.'/NameFieldTraitTest/';
+    protected const TEST_FIELD_FQN =   NameFieldTrait::class;
+    protected const TEST_FIELD_PROP =  NameFieldInterface::PROP_NAME;
+}

--- a/tests/Entity/Fields/Traits/Attribute/QtyFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/Attribute/QtyFieldTraitTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Attribute;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Attribute\QtyFieldInterface; 
+
+class QtyFieldTraitTest extends AbstractFieldTraitTest
+{
+    public const WORK_DIR = AbstractTest::VAR_PATH.'/QtyFieldTraitTest/';
+    protected const TEST_FIELD_FQN =   QtyFieldTrait::class;
+    protected const TEST_FIELD_PROP =  QtyFieldInterface::PROP_QTY;
+}

--- a/tests/Entity/Fields/Traits/Date/ActionedDateFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/Date/ActionedDateFieldTraitTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Date;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Date\ActionedDateFieldInterface;
+
+class ActionedDateFieldTraitTest extends AbstractFieldTraitTest
+{
+    public const WORK_DIR = AbstractTest::VAR_PATH.'/ActionedDateFieldTraitTest/';
+    protected const TEST_FIELD_FQN =   ActionedDateFieldTrait::class;
+    protected const TEST_FIELD_PROP =  ActionedDateFieldInterface::PROP_ACTIONED_DATE;
+}

--- a/tests/Entity/Fields/Traits/Date/ActivatedDateFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/Date/ActivatedDateFieldTraitTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Date;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Date\ActivatedDateFieldInterface;
+
+class ActivatedDateFieldTraitTest extends AbstractFieldTraitTest
+{
+    public const WORK_DIR = AbstractTest::VAR_PATH.'/ActivatedDateFieldTraitTest/';
+    protected const TEST_FIELD_FQN =   ActivatedDateFieldTrait::class;
+    protected const TEST_FIELD_PROP =  ActivatedDateFieldInterface::PROP_ACTIVATED_DATE;
+}

--- a/tests/Entity/Fields/Traits/Date/CompletedDateFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/Date/CompletedDateFieldTraitTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Date;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Date\CompletedDateFieldInterface;
+
+class CompletedDateFieldTraitTest extends AbstractFieldTraitTest
+{
+    public const WORK_DIR = AbstractTest::VAR_PATH.'/CompletedDateFieldTraitTest/';
+    protected const TEST_FIELD_FQN =   CompletedDateFieldTrait::class;
+    protected const TEST_FIELD_PROP =  CompletedDateFieldInterface::PROP_COMPLETED_DATE;
+}

--- a/tests/Entity/Fields/Traits/Date/DeactivatedDateFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/Date/DeactivatedDateFieldTraitTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Date;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Date\DeactivatedDateFieldInterface;
+
+class DeactivatedDateFieldTraitTest extends AbstractFieldTraitTest
+{
+    public const WORK_DIR = AbstractTest::VAR_PATH.'/DeactivatedDateFieldTraitTest/';
+    protected const TEST_FIELD_FQN =   DeactivatedDateFieldTrait::class;
+    protected const TEST_FIELD_PROP =  DeactivatedDateFieldInterface::PROP_DEACTIVATED_DATE;
+}

--- a/tests/Entity/Fields/Traits/Date/TimestampFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/Date/TimestampFieldTraitTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Date;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Date\TimestampFieldInterface; 
+
+class TimestampFieldTraitTest extends AbstractFieldTraitTest
+{
+    public const WORK_DIR = AbstractTest::VAR_PATH.'/TimestampFieldTraitTest/';
+    protected const TEST_FIELD_FQN =   TimestampFieldTrait::class;
+    protected const TEST_FIELD_PROP =  TimestampFieldInterface::PROP_TIMESTAMP;
+}

--- a/tests/Entity/Fields/Traits/Flag/ApprovedFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/Flag/ApprovedFieldTraitTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Flag;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Flag\ApprovedFieldInterface; 
+
+class ApprovedFieldTraitTest extends AbstractFieldTraitTest
+{
+    public const WORK_DIR = AbstractTest::VAR_PATH.'/ApprovedFieldTraitTest/';
+    protected const TEST_FIELD_FQN =   ApprovedFieldTrait::class;
+    protected const TEST_FIELD_PROP =  ApprovedFieldInterface::PROP_APPROVED;
+}

--- a/tests/Entity/Fields/Traits/Flag/ApprovedFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/Flag/ApprovedFieldTraitTest.php
@@ -3,12 +3,13 @@
 namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Flag;
 
 use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Flag\ApprovedFieldInterface;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
-use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Flag\ApprovedFieldInterface; 
 
 class ApprovedFieldTraitTest extends AbstractFieldTraitTest
 {
-    public const WORK_DIR = AbstractTest::VAR_PATH.'/ApprovedFieldTraitTest/';
-    protected const TEST_FIELD_FQN =   ApprovedFieldTrait::class;
-    protected const TEST_FIELD_PROP =  ApprovedFieldInterface::PROP_APPROVED;
+    public const    WORK_DIR           = AbstractTest::VAR_PATH.'/ApprovedFieldTraitTest/';
+    protected const TEST_FIELD_FQN     = ApprovedFieldTrait::class;
+    protected const TEST_FIELD_PROP    = ApprovedFieldInterface::PROP_APPROVED;
+    protected const TEST_FIELD_DEFAULT = ApprovedFieldInterface::DEFAULT_APPROVED;
 }

--- a/tests/Entity/Fields/Traits/Flag/DefaultFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/Flag/DefaultFieldTraitTest.php
@@ -3,12 +3,13 @@
 namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Flag;
 
 use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Flag\DefaultFieldInterface;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
-use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Flag\DefaultFieldInterface; 
 
 class DefaultFieldTraitTest extends AbstractFieldTraitTest
 {
-    public const WORK_DIR = AbstractTest::VAR_PATH.'/DefaultFieldTraitTest/';
-    protected const TEST_FIELD_FQN =   DefaultFieldTrait::class;
-    protected const TEST_FIELD_PROP =  DefaultFieldInterface::PROP_DEFAULT;
+    public const    WORK_DIR           = AbstractTest::VAR_PATH.'/DefaultFieldTraitTest/';
+    protected const TEST_FIELD_FQN     = DefaultFieldTrait::class;
+    protected const TEST_FIELD_PROP    = DefaultFieldInterface::PROP_DEFAULT;
+    protected const TEST_FIELD_DEFAULT = DefaultFieldInterface::DEFAULT_DEFAULT;
 }

--- a/tests/Entity/Fields/Traits/Flag/DefaultFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/Flag/DefaultFieldTraitTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Flag;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Flag\DefaultFieldInterface; 
+
+class DefaultFieldTraitTest extends AbstractFieldTraitTest
+{
+    public const WORK_DIR = AbstractTest::VAR_PATH.'/DefaultFieldTraitTest/';
+    protected const TEST_FIELD_FQN =   DefaultFieldTrait::class;
+    protected const TEST_FIELD_PROP =  DefaultFieldInterface::PROP_DEFAULT;
+}

--- a/tests/Entity/Fields/Traits/Person/EmailFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/Person/EmailFieldTraitTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Person;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Person\EmailFieldInterface; 
+
+class EmailFieldTraitTest extends AbstractFieldTraitTest
+{
+    public const WORK_DIR = AbstractTest::VAR_PATH.'/EmailFieldTraitTest/';
+    protected const TEST_FIELD_FQN =   EmailFieldTrait::class;
+    protected const TEST_FIELD_PROP =  EmailFieldInterface::PROP_EMAIL;
+}

--- a/tests/Entity/Fields/Traits/Person/YearOfBirthFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/Person/YearOfBirthFieldTraitTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\Person;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\Person\YearOfBirthFieldInterface;
+
+class YearOfBirthFieldTraitTest extends AbstractFieldTraitTest
+{
+    public const WORK_DIR = AbstractTest::VAR_PATH.'/YearOfBirthFieldTraitTest/';
+    protected const TEST_FIELD_FQN =   YearOfBirthFieldTrait::class;
+    protected const TEST_FIELD_PROP =  YearOfBirthFieldInterface::PROP_YEAR_OF_BIRTH;
+}

--- a/tests/Entity/Fields/Traits/PrimaryKey/IdFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/PrimaryKey/IdFieldTraitTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\PrimaryKey;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\PrimaryKey\IdFieldInterface; 
+
+class IdFieldTraitTest extends AbstractFieldTraitTest
+{
+    public const WORK_DIR = AbstractTest::VAR_PATH.'/IdFieldTraitTest/';
+    protected const TEST_FIELD_FQN =   IdFieldTrait::class;
+    protected const TEST_FIELD_PROP =  IdFieldInterface::PROP_ID;
+}

--- a/tests/Entity/Fields/Traits/PrimaryKey/IdFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/PrimaryKey/IdFieldTraitTest.php
@@ -12,10 +12,8 @@ class IdFieldTraitTest extends AbstractFieldTraitTest
     protected const TEST_FIELD_FQN  = IdFieldTrait::class;
     protected const TEST_FIELD_PROP = IdFieldInterface::PROP_ID;
 
-    public function setup()
+    public function generateCode()
     {
-        parent::setup();
-        $this->entitySuffix = substr(static::class, strrpos(static::class, '\\') + 1);
         $this->getEntityGenerator()
              ->generateEntity(static::TEST_ENTITY_FQN_BASE.$this->entitySuffix);
         $this->setupCopiedWorkDir();
@@ -30,7 +28,7 @@ class IdFieldTraitTest extends AbstractFieldTraitTest
      */
     public function testCreateEntityWithField(): void
     {
-        $entityFqn = $this->getCopiedFqn(static::TEST_ENTITY_FQN_BASE);
+        $entityFqn = $this->getCopiedFqn(static::TEST_ENTITY_FQN_BASE.$this->entitySuffix);
         $entity    = new $entityFqn();
         $getter    = $this->getGetter($entity);
         $this->assertTrue(\method_exists($entity, $getter));

--- a/tests/Entity/Fields/Traits/PrimaryKey/IdFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/PrimaryKey/IdFieldTraitTest.php
@@ -3,12 +3,38 @@
 namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\PrimaryKey;
 
 use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\PrimaryKey\IdFieldInterface;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
-use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\PrimaryKey\IdFieldInterface; 
 
 class IdFieldTraitTest extends AbstractFieldTraitTest
 {
-    public const WORK_DIR = AbstractTest::VAR_PATH.'/IdFieldTraitTest/';
-    protected const TEST_FIELD_FQN =   IdFieldTrait::class;
-    protected const TEST_FIELD_PROP =  IdFieldInterface::PROP_ID;
+    public const    WORK_DIR        = AbstractTest::VAR_PATH.'/IdFieldTraitTest/';
+    protected const TEST_FIELD_FQN  = IdFieldTrait::class;
+    protected const TEST_FIELD_PROP = IdFieldInterface::PROP_ID;
+
+    public function setup()
+    {
+        parent::setup();
+        $this->entitySuffix = substr(static::class, strrpos(static::class, '\\') + 1);
+        $this->getEntityGenerator()
+             ->generateEntity(static::TEST_ENTITY_FQN_BASE.$this->entitySuffix);
+        $this->setupCopiedWorkDir();
+    }
+
+
+    /**
+     * Can't really do setters etc on ID fields
+     *
+     * @throws \EdmondsCommerce\DoctrineStaticMeta\Exception\DoctrineStaticMetaException
+     * @throws \ReflectionException
+     */
+    public function testCreateEntityWithField(): void
+    {
+        $entityFqn = $this->getCopiedFqn(static::TEST_ENTITY_FQN_BASE);
+        $entity    = new $entityFqn();
+        $getter    = $this->getGetter($entity);
+        $this->assertTrue(\method_exists($entity, $getter));
+        $value = $entity->$getter();
+        $this->assertEmpty($value);
+    }
 }

--- a/tests/Entity/Fields/Traits/PrimaryKey/UuidFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/PrimaryKey/UuidFieldTraitTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\PrimaryKey;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\PrimaryKey\UuidFieldInterface; 
+
+class UuidFieldTraitTest extends AbstractFieldTraitTest
+{
+    public const WORK_DIR = AbstractTest::VAR_PATH.'/UuidFieldTraitTest/';
+    protected const TEST_FIELD_FQN =   UuidFieldTrait::class;
+    protected const TEST_FIELD_PROP =  UuidFieldInterface::PROP_UUID;
+}

--- a/tests/Entity/Fields/Traits/PrimaryKey/UuidFieldTraitTest.php
+++ b/tests/Entity/Fields/Traits/PrimaryKey/UuidFieldTraitTest.php
@@ -3,12 +3,11 @@
 namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\PrimaryKey;
 
 use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
-use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Traits\AbstractFieldTraitTest;
-use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\PrimaryKey\UuidFieldInterface; 
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Fields\Interfaces\PrimaryKey\IdFieldInterface;
 
-class UuidFieldTraitTest extends AbstractFieldTraitTest
+class UuidFieldTraitTest extends IdFieldTraitTest
 {
-    public const WORK_DIR = AbstractTest::VAR_PATH.'/UuidFieldTraitTest/';
-    protected const TEST_FIELD_FQN =   UuidFieldTrait::class;
-    protected const TEST_FIELD_PROP =  UuidFieldInterface::PROP_UUID;
+    public const    WORK_DIR        = AbstractTest::VAR_PATH.'/UuidFieldTraitTest/';
+    protected const TEST_FIELD_FQN  = UuidFieldTrait::class;
+    protected const TEST_FIELD_PROP = IdFieldInterface::PROP_ID;
 }

--- a/tests/Entity/Repositories/AbstractEntityRepositoryTest.php
+++ b/tests/Entity/Repositories/AbstractEntityRepositoryTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Repositories;
+
+use EdmondsCommerce\DoctrineStaticMeta\AbstractTest;
+use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\AbstractGenerator;
+
+class AbstractEntityRepositoryTest extends AbstractTest
+{
+    public const WORK_DIR = AbstractTest::VAR_PATH.'/AbstractEntityRepositoryTest';
+
+    public function testLoadingWithoutMetaData()
+    {
+        $entityFqn     = static::TEST_PROJECT_ROOT_NAMESPACE
+                         .'\\'.AbstractGenerator::ENTITIES_FOLDER_NAME
+                         .'\\Yet\\Another\\TestEntity';
+        $repositoryFqn = static::TEST_PROJECT_ROOT_NAMESPACE
+                         .'\\'.AbstractGenerator::ENTITY_REPOSITORIES_NAMESPACE
+                         .'\\Yet\\Another\\TestEntityRepository';
+        $this->getEntityGenerator()->generateEntity($entityFqn);
+        $this->setupCopiedWorkDir();
+        $entityFqn     = $this->getCopiedFqn($entityFqn);
+        $repositoryFqn = $this->getCopiedFqn($repositoryFqn);
+        /**
+         * @var AbstractEntityRepository $repository
+         */
+        $repository = new $repositoryFqn($this->getEntityManager());
+        $this->assertInstanceOf($repositoryFqn, $repository);
+        $expected = ltrim($entityFqn, '\\');
+        $actual   = $repository->getClassName();
+        $this->assertEquals($expected, $actual);
+    }
+
+}

--- a/tests/Entity/Repositories/AbstractEntityRepositoryTest.php
+++ b/tests/Entity/Repositories/AbstractEntityRepositoryTest.php
@@ -28,7 +28,7 @@ class AbstractEntityRepositoryTest extends AbstractTest
         $this->assertInstanceOf($repositoryFqn, $repository);
         $expected = ltrim($entityFqn, '\\');
         $actual   = $repository->getClassName();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
 }

--- a/tests/Entity/Validation/EntityValidatorTest.php
+++ b/tests/Entity/Validation/EntityValidatorTest.php
@@ -61,7 +61,7 @@ class EntityValidatorTest extends AbstractTest
     {
         foreach (self::VALID_IP_ADDRESSES as $ipAddress) {
             $this->testEntity->setIpAddress($ipAddress);
-            $this->assertEquals($ipAddress, $this->testEntity->getIpAddress());
+            $this->assertSame($ipAddress, $this->testEntity->getIpAddress());
         }
     }
 

--- a/tests/GeneratedCode/GeneratedCodeTest.php
+++ b/tests/GeneratedCode/GeneratedCodeTest.php
@@ -653,7 +653,7 @@ BASH;
         }
         foreach (self::UNIQUEABLE_FIELD_TYPES as $uniqueableType) {
             $fieldFqn = self::TEST_FIELD_TRAIT_NAMESPACE.'\\Unique'.ucwords($uniqueableType);
-            $this->generateField($fieldFqn, $uniqueableType, true, true);
+            $this->generateField($fieldFqn, $uniqueableType, null, true);
         }
     }
 

--- a/tests/GeneratedCode/GeneratedCodeTest.php
+++ b/tests/GeneratedCode/GeneratedCodeTest.php
@@ -506,10 +506,10 @@ DOCTRINE;
     --field-property-doctrine-type="{$type}"
 DOCTRINE;
         if (null !== $default) {
-            $doctrineCmd .= ' --'.GenerateFieldCommand::OPT_DEFAULT_VALUE.'="$default"';
+            $doctrineCmd .= ' --'.GenerateFieldCommand::OPT_DEFAULT_VALUE.'="'.$default."\\\n";
         }
         if (true === $isUnique) {
-            $doctrineCmd .= ' --'.GenerateFieldCommand::OPT_IS_UNIQUE;
+            $doctrineCmd .= ' --'.GenerateFieldCommand::OPT_IS_UNIQUE."\\\n";
         }
         $this->execDoctrine($doctrineCmd);
     }

--- a/tests/GeneratedCode/GeneratedCodeTest.php
+++ b/tests/GeneratedCode/GeneratedCodeTest.php
@@ -506,7 +506,7 @@ DOCTRINE;
     --field-property-doctrine-type="{$type}"
 DOCTRINE;
         if (null !== $default) {
-            $doctrineCmd .= ' --'.GenerateFieldCommand::OPT_DEFAULT_VALUE.'="'.$default."\\\n";
+            $doctrineCmd .= ' --'.GenerateFieldCommand::OPT_DEFAULT_VALUE.'="'.$default.'"'."\\\n";
         }
         if (true === $isUnique) {
             $doctrineCmd .= ' --'.GenerateFieldCommand::OPT_IS_UNIQUE."\\\n";

--- a/tests/GeneratedCode/GeneratedCodeTest.php
+++ b/tests/GeneratedCode/GeneratedCodeTest.php
@@ -485,16 +485,16 @@ DOCTRINE;
     }
 
     /**
-     * @param string $propertyName
-     * @param string $type
-     * @param bool   $isNullable
-     * @param bool   $isUnique
+     * @param string     $propertyName
+     * @param string     $type
+     * @param mixed|null $default
+     * @param bool       $isUnique
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
     protected function generateField(
         string $propertyName,
         string $type,
-        bool $isNullable = true,
+        $default = null,
         bool $isUnique = false
     ) {
         $namespace   = self::TEST_PROJECT_ROOT_NAMESPACE;
@@ -505,8 +505,8 @@ DOCTRINE;
     --field-fully-qualified-name="{$propertyName}" \
     --field-property-doctrine-type="{$type}"
 DOCTRINE;
-        if (false === $isNullable) {
-            $doctrineCmd .= ' --'.GenerateFieldCommand::OPT_DEFAULT_VALUE;
+        if (null !== $default) {
+            $doctrineCmd .= ' --'.GenerateFieldCommand::OPT_DEFAULT_VALUE.'="$default"';
         }
         if (true === $isUnique) {
             $doctrineCmd .= ' --'.GenerateFieldCommand::OPT_IS_UNIQUE;

--- a/tests/GeneratedCode/GeneratedCodeTest.php
+++ b/tests/GeneratedCode/GeneratedCodeTest.php
@@ -506,7 +506,7 @@ DOCTRINE;
     --field-property-doctrine-type="{$type}"
 DOCTRINE;
         if (false === $isNullable) {
-            $doctrineCmd .= ' --'.GenerateFieldCommand::OPT_NOT_NULLABLE;
+            $doctrineCmd .= ' --'.GenerateFieldCommand::OPT_DEFAULT_VALUE;
         }
         if (true === $isUnique) {
             $doctrineCmd .= ' --'.GenerateFieldCommand::OPT_IS_UNIQUE;

--- a/tests/MappingHelperTest.php
+++ b/tests/MappingHelperTest.php
@@ -3,8 +3,10 @@
 namespace EdmondsCommerce\DoctrineStaticMeta;
 
 use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\AbstractGenerator;
-use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\RelationsGenerator;
 
+/**
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
 class MappingHelperTest extends AbstractTest
 {
     public const WORK_DIR = AbstractTest::VAR_PATH.'/MappingHelperTest';
@@ -19,33 +21,29 @@ class MappingHelperTest extends AbstractTest
     public const TEST_ENTITY_POST_CREATED        = self::TEST_ENTITY_FQN_BASE.'\\Meh';
     public const TEST_ENTITY_POST_CREATED_NESTED = self::TEST_ENTITY_FQN_BASE.'\\Nested\\Something\\Ho\\Hum';
 
-    /**
-     * @throws Exception\DoctrineStaticMetaException
-     */
     public function setup()
     {
-        parent::setup();
-        $entityGenerator    = $this->getEntityGenerator();
-        $relationsGenerator = $this->getRelationsGenerator();
-        foreach (self::TEST_ENTITIES as $fqn) {
-            $entityGenerator->generateEntity($fqn);
-            $relationsGenerator->generateRelationCodeForEntity($fqn);
-        }
-        $relationsGenerator->setEntityHasRelationToEntity(
-            self::TEST_ENTITIES[0],
-            RelationsGenerator::HAS_MANY_TO_MANY,
-            self::TEST_ENTITIES[1]
-        );
+        // simply overriding setup to disable parent::setup
     }
 
-    /**
-     * @SuppressWarnings(PHPMD.StaticAccess)
-     */
+
     public function testGetTableNameForEntityFqn()
     {
         $expected  = '`bar_baz`';
         $entityFqn = '\\DSM\\Test\\Project\\Entities\\Bar\\Baz';
         $actual    = MappingHelper::getTableNameForEntityFqn($entityFqn);
         $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetColumnName()
+    {
+        $fieldNamesToExpectedColumnNames = [
+            'test'                   => '`test`',
+            'longThingWithCamelCase' => '`long_thing_with_camel_case`',
+        ];
+        foreach ($fieldNamesToExpectedColumnNames as $field => $expected) {
+            $actual = MappingHelper::getColumnNameForField($field);
+            $this->assertEquals($expected, $actual);
+        }
     }
 }

--- a/tests/MappingHelperTest.php
+++ b/tests/MappingHelperTest.php
@@ -32,7 +32,7 @@ class MappingHelperTest extends AbstractTest
         $expected  = '`bar_baz`';
         $entityFqn = '\\DSM\\Test\\Project\\Entities\\Bar\\Baz';
         $actual    = MappingHelper::getTableNameForEntityFqn($entityFqn);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function testGetColumnName()
@@ -43,7 +43,7 @@ class MappingHelperTest extends AbstractTest
         ];
         foreach ($fieldNamesToExpectedColumnNames as $field => $expected) {
             $actual = MappingHelper::getColumnNameForField($field);
-            $this->assertEquals($expected, $actual);
+            $this->assertSame($expected, $actual);
         }
     }
 }


### PR DESCRIPTION
Set out to improve code coverage for field traits among other things

Realised that we really need default values and it spiralled into a massive refactor to support this new functionality

We now have the concept of default values which, if set to null, mean the field is nullable

If the field is not nullable, then the default value is returned