### PR TITLE
Add PHPMD warning suppression for number of children

### DIFF
--- a/src/Entity/Repositories/AbstractEntityRepository.php
+++ b/src/Entity/Repositories/AbstractEntityRepository.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
  * @package EdmondsCommerce\DoctrineStaticMeta\Entity\Repositories
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  * @SuppressWarnings(PHPMD.ExcessivePublicCount)
+ * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
 abstract class AbstractEntityRepository implements EntityRepositoryInterface
 {

--- a/src/Entity/Testing/AbstractEntityTest.php
+++ b/src/Entity/Testing/AbstractEntityTest.php
@@ -35,6 +35,7 @@ use Symfony\Component\Validator\Mapping\Cache\DoctrineCache;
  *
  * @package EdmondsCommerce\DoctrineStaticMeta\Entity
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
 abstract class AbstractEntityTest extends TestCase implements EntityTestInterface
 {


### PR DESCRIPTION
As the number of entities grows you eventually hit the limit of 15. This is expected and should be ignored by PHPMD.