### PR TITLE
Fix str replace issue

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1731,7 +1731,7 @@
                 "fixtures"
             ],
             "support": {
-                "source": "https://github.com/edmondscommerce/Faker/tree/master"
+                "source": "https://github.com/edmondscommerce/Faker/tree/dsm-patches"
             },
             "time": "2018-04-18T15:33:12+00:00"
         },
@@ -2756,16 +2756,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.0.6",
+            "version": "6.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "1661926cfa5be825d4f96f89dfac46dc4a19afa8"
+                "reference": "865662550c384bc1db7e51d29aeda1c2c161d69a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/1661926cfa5be825d4f96f89dfac46dc4a19afa8",
-                "reference": "1661926cfa5be825d4f96f89dfac46dc4a19afa8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/865662550c384bc1db7e51d29aeda1c2c161d69a",
+                "reference": "865662550c384bc1db7e51d29aeda1c2c161d69a",
                 "shasum": ""
             },
             "require": {
@@ -2815,7 +2815,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-06-01T05:41:09+00:00"
+            "time": "2018-06-01T07:51:50+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3005,16 +3005,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.2.0",
+            "version": "7.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "be2835aff47ce925b53bc8a693d49c2973bd5f67"
+                "reference": "3cf0836680bf5c365c627e8566d46c9e1f544db9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/be2835aff47ce925b53bc8a693d49c2973bd5f67",
-                "reference": "be2835aff47ce925b53bc8a693d49c2973bd5f67",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3cf0836680bf5c365c627e8566d46c9e1f544db9",
+                "reference": "3cf0836680bf5c365c627e8566d46c9e1f544db9",
                 "shasum": ""
             },
             "require": {
@@ -3029,7 +3029,7 @@
                 "phar-io/version": "^1.0",
                 "php": "^7.1",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0.6",
+                "phpunit/php-code-coverage": "^6.0.7",
                 "phpunit/php-file-iterator": "^2.0",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^2.0",
@@ -3085,7 +3085,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-06-01T05:47:14+00:00"
+            "time": "2018-06-01T07:54:27+00:00"
         },
         {
             "name": "pimple/pimple",

--- a/src/Entity/Savers/AbstractEntitySpecificSaver.php
+++ b/src/Entity/Savers/AbstractEntitySpecificSaver.php
@@ -86,18 +86,17 @@ abstract class AbstractEntitySpecificSaver extends EntitySaver
     {
         if (null === $this->entityFqn) {
             $this->entityFqn = \str_replace(
-                [
-                    'Entity\\Savers',
-                    'Saver',
-                ],
-                [
-                    'Entities',
-                    '',
-                ],
-                static::class
+                '\\Entity\\Savers\\',
+                '\\Entities\\',
+                $this->cropSaver(static::class)
             );
         }
 
         return $this->entityFqn;
+    }
+
+    protected function cropSaver(string $fqn)
+    {
+        return \substr($fqn, 0, - \strlen('Saver'));
     }
 }


### PR DESCRIPTION
Prevent's the string `'Saver'` from being removed anywhere other than the end of the FQN.

I've also made the other matches more specific.