### PR TITLE
Entities with Dependencies

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,8 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/edmondscommerce/phpqa" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/edmondscommerce/typesafe-functions" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/fzaninotto/faker" vcs="Git" />
   </component>
 </project>

--- a/codeTemplates/src/Entities/TemplateEntity.php
+++ b/codeTemplates/src/Entities/TemplateEntity.php
@@ -22,7 +22,7 @@ class TemplateEntity implements TemplateEntityInterface
     public function __construct(DSM\Validation\EntityValidatorFactory $entityValidatorFactory)
     {
         $this->runInitMethods();
-        $this->injectDependencies($entityValidatorFactory);
+        $this->injectDependencies([$entityValidatorFactory]);
 
     }
 
@@ -31,11 +31,16 @@ class TemplateEntity implements TemplateEntityInterface
      *
      * It should duplicate the dependencies that are injected via the __construct
      *
-     * @param DSM\Validation\EntityValidatorFactory $entityValidatorFactory
+     * You must have a property that is the ucfirst of the dependency shortName
+     *
+     * @param object[] ...$extraDependencies
      */
-    public function injectDependencies(DSM\Validation\EntityValidatorFactory $entityValidatorFactory): void
+    public function injectDependencies(...$extraDependencies): void
     {
-        $this->injectValidator($entityValidatorFactory->getEntityValidator());
+        foreach ($extraDependencies as $extraDependency) {
+            $property        = ucfirst(basename(str_replace('\\', '/', \get_class($extraDependency))));
+            $this->$property = $extraDependency;
+        }
     }
 
     /**

--- a/codeTemplates/src/Entities/TemplateEntity.php
+++ b/codeTemplates/src/Entities/TemplateEntity.php
@@ -6,7 +6,6 @@ namespace TemplateNamespace\Entities;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use EdmondsCommerce\DoctrineStaticMeta\Entity as DSM;
 use TemplateNamespace\Entity\Interfaces\TemplateEntityInterface;
-use TemplateNamespace\Entity\Repositories\TemplateEntityRepository;
 
 class TemplateEntity implements TemplateEntityInterface
 {
@@ -23,10 +22,27 @@ class TemplateEntity implements TemplateEntityInterface
     public function __construct(DSM\Validation\EntityValidatorFactory $entityValidatorFactory)
     {
         $this->runInitMethods();
+        $this->injectDependencies($entityValidatorFactory);
+
+    }
+
+    /**
+     * This method is called when your Entity is loaded from your EntityRepository
+     *
+     * It should duplicate the dependencies that are injected via the __construct
+     *
+     * @param DSM\Validation\EntityValidatorFactory $entityValidatorFactory
+     */
+    public function injectDependencies(DSM\Validation\EntityValidatorFactory $entityValidatorFactory)
+    {
         $this->injectValidator($entityValidatorFactory->getEntityValidator());
     }
 
     /**
+     * In this method, we deliberately disable the concept of loading a repository via entityManager.
+     *
+     * This forces you to use dependency injection or manual instantiation of TemplateEntityRepository
+     *
      * This is called in UsesPHPMetaDataTrait::loadClassDoctrineMetaData
      *
      * @param ClassMetadataBuilder $builder
@@ -34,7 +50,7 @@ class TemplateEntity implements TemplateEntityInterface
      */
     private static function setCustomRepositoryClass(ClassMetadataBuilder $builder)
     {
-        $builder->setCustomRepositoryClass(TemplateEntityRepository::class);
+        $builder->setCustomRepositoryClass(DSM\Repositories\DisabledRepository::class);
     }
 
 

--- a/codeTemplates/src/Entities/TemplateEntity.php
+++ b/codeTemplates/src/Entities/TemplateEntity.php
@@ -33,7 +33,7 @@ class TemplateEntity implements TemplateEntityInterface
      *
      * @param DSM\Validation\EntityValidatorFactory $entityValidatorFactory
      */
-    public function injectDependencies(DSM\Validation\EntityValidatorFactory $entityValidatorFactory)
+    public function injectDependencies(DSM\Validation\EntityValidatorFactory $entityValidatorFactory): void
     {
         $this->injectValidator($entityValidatorFactory->getEntityValidator());
     }

--- a/codeTemplates/src/Entities/TemplateEntity.php
+++ b/codeTemplates/src/Entities/TemplateEntity.php
@@ -22,7 +22,7 @@ class TemplateEntity implements TemplateEntityInterface
     public function __construct(DSM\Validation\EntityValidatorFactory $entityValidatorFactory)
     {
         $this->runInitMethods();
-        $this->injectDependencies([$entityValidatorFactory]);
+        $this->injectDependencies($entityValidatorFactory);
 
     }
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "symfony/validator": "^4.0",
     "moneyphp/money": "^3.1",
     "symfony/intl": "^4.1",
-    "edmondscommerce/typesafe-functions": "~0"
+    "edmondscommerce/typesafe-functions": "~0@dev"
   },
   "require-dev": {
     "fzaninotto/faker": "dev-dsm-patches@dev",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "symfony/validator": "^4.0",
     "moneyphp/money": "^3.1",
     "symfony/intl": "^4.1",
-    "edmondscommerce/typesafe-functions": "dev-master@dev"
+    "edmondscommerce/typesafe-functions": "~0"
   },
   "require-dev": {
     "fzaninotto/faker": "dev-dsm-patches@dev",

--- a/src/Config.php
+++ b/src/Config.php
@@ -11,7 +11,7 @@ class Config implements ConfigInterface
 {
 
     private static $projectRootDirectory;
-    private        $config = [];
+    private $config = [];
 
     /**
      * Config constructor.

--- a/src/Entity/Interfaces/EntityInterface.php
+++ b/src/Entity/Interfaces/EntityInterface.php
@@ -8,7 +8,8 @@ interface EntityInterface extends
     UsesPHPMetaDataInterface,
     ValidatedEntityInterface,
     DSM\Fields\Interfaces\PrimaryKey\IdFieldInterface,
-    ImplementNotifyChangeTrackingPolicyInterface
+    ImplementNotifyChangeTrackingPolicyInterface,
+    InjectsDependenciesInterface
 {
 
 }

--- a/src/Entity/Interfaces/InjectsDependenciesInterface.php
+++ b/src/Entity/Interfaces/InjectsDependenciesInterface.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces;
+
+/**
+ * Dependencies are injected with either the constructor (as normal) or using this method when loaded in the repository
+ *
+ * Interface InjectsDependenciesInterface
+ *
+ * @package EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces
+ */
+interface InjectsDependenciesInterface
+{
+    public function injectDependencies(...$extraDependencies): void;
+}

--- a/src/Entity/Repositories/AbstractEntityRepository.php
+++ b/src/Entity/Repositories/AbstractEntityRepository.php
@@ -102,14 +102,14 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
     protected function getEntityFqn(): string
     {
         return '\\'.\str_replace(
-                [
+            [
                     'Entity\\Repositories',
                 ],
-                [
+            [
                     'Entities',
                 ],
-                $this->namespaceHelper->cropSuffix(static::class, 'Repository')
-            );
+            $this->namespaceHelper->cropSuffix(static::class, 'Repository')
+        );
     }
 
     public function find($id, ?int $lockMode = null, ?int $lockVersion = null): ?EntityInterface

--- a/src/Entity/Repositories/AbstractEntityRepository.php
+++ b/src/Entity/Repositories/AbstractEntityRepository.php
@@ -15,7 +15,6 @@ use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\NamespaceHelper;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces\EntityInterface;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Validation\EntityValidatorFactory;
 use Symfony\Component\Validator\Mapping\Cache\DoctrineCache;
-use ts\Reflection\ReflectionClass;
 
 /**
  * Class AbstractEntityRepository
@@ -91,24 +90,8 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
     ) {
         $this->entityManager   = $entityManager;
         $this->namespaceHelper = $namespaceHelper;
+        $this->extraDependencies = $extraDependencies;
         $this->initRepository();
-        $this->setExtraDependencies($extraDependencies);
-    }
-
-    /**
-     * @param array $extraDependencies
-     *
-     * @throws \ReflectionException
-     */
-    protected function setExtraDependencies(array $extraDependencies)
-    {
-        foreach ($extraDependencies as $extraDependency) {
-            $reflection                                      = new ReflectionClass(\get_class($extraDependency));
-            $this->extraDependencies[$reflection->getName()] = [
-                'instance'   => $extraDependency,
-                'reflection' => $reflection,
-            ];
-        }
     }
 
     protected function initRepository(): void

--- a/src/Entity/Repositories/AbstractEntityRepository.php
+++ b/src/Entity/Repositories/AbstractEntityRepository.php
@@ -77,19 +77,17 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
      *
      * AbstractEntityRepositoryFactory constructor.
      *
-     * @param EntityManager        $entityManager
-     * @param NamespaceHelper|null $namespaceHelper
-     * @param array                $extraDependencies
-     *
-     * @throws \ReflectionException
+     * @param EntityManager   $entityManager
+     * @param NamespaceHelper $namespaceHelper
+     * @param mixed           ...$extraDependencies
      */
     public function __construct(
         EntityManager $entityManager,
         NamespaceHelper $namespaceHelper,
         ...$extraDependencies
     ) {
-        $this->entityManager   = $entityManager;
-        $this->namespaceHelper = $namespaceHelper;
+        $this->entityManager     = $entityManager;
+        $this->namespaceHelper   = $namespaceHelper;
         $this->extraDependencies = $extraDependencies;
         $this->initRepository();
     }

--- a/src/Entity/Repositories/DisabledRepository.php
+++ b/src/Entity/Repositories/DisabledRepository.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Persistence\ObjectRepository;
  * Class DisabledRepository
  *
  * @package EdmondsCommerce\DoctrineStaticMeta\Entity\Repositories
+ * @SuppressWarnings(PHPMD)
  */
 class DisabledRepository implements ObjectRepository
 {

--- a/src/Entity/Repositories/DisabledRepository.php
+++ b/src/Entity/Repositories/DisabledRepository.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Repositories;
+
+use Doctrine\Common\Persistence\ObjectRepository;
+
+/**
+ * This is a dummy repository that just throws a logic exception
+ *
+ * Class DisabledRepository
+ *
+ * @package EdmondsCommerce\DoctrineStaticMeta\Entity\Repositories
+ */
+class DisabledRepository implements ObjectRepository
+{
+    public function __construct()
+    {
+        $this->except();
+    }
+
+    private function except()
+    {
+        throw new \LogicException(
+            'You can not load the repository via entityManager.'
+            .' Instead, you must use DI or manual instantiation of your Entities generated repository'
+        );
+    }
+
+    /**
+     * Finds an object by its primary key / identifier.
+     *
+     * @param mixed $id The identifier.
+     *
+     * @return object|null The object.
+     */
+    public function find($id)
+    {
+        $this->except();
+    }
+
+    /**
+     * Finds all objects in the repository.
+     *
+     * @return object[] The objects.
+     */
+    public function findAll()
+    {
+        $this->except();
+    }
+
+    /**
+     * Finds objects by a set of criteria.
+     *
+     * Optionally sorting and limiting details can be passed. An implementation may throw
+     * an UnexpectedValueException if certain values of the sorting or limiting details are
+     * not supported.
+     *
+     * @param mixed[]       $criteria
+     * @param string[]|null $orderBy
+     * @param int|null      $limit
+     * @param int|null      $offset
+     *
+     * @return object[] The objects.
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null)
+    {
+        $this->except();
+    }
+
+    /**
+     * Finds a single object by a set of criteria.
+     *
+     * @param mixed[] $criteria The criteria.
+     *
+     * @return object|null The object.
+     */
+    public function findOneBy(array $criteria)
+    {
+        $this->except();
+    }
+
+    /**
+     * Returns the class name of the object managed by the repository.
+     *
+     * @return string
+     */
+    public function getClassName()
+    {
+        $this->except();
+    }
+}

--- a/src/Entity/Testing/AbstractEntityTest.php
+++ b/src/Entity/Testing/AbstractEntityTest.php
@@ -135,8 +135,6 @@ abstract class AbstractEntityTest extends TestCase implements EntityTestInterfac
         $entityRepositoryFqn .= 'Repository';
 
         return $entityRepositoryFqn;
-
-
     }
 
     /**

--- a/src/Entity/Testing/AbstractEntityTest.php
+++ b/src/Entity/Testing/AbstractEntityTest.php
@@ -130,7 +130,7 @@ abstract class AbstractEntityTest extends TestCase implements EntityTestInterfac
     protected function getTestedEntityRepositoryFqn(): string
     {
         $entityFqn           = $this->getTestedEntityFqn();
-        $entityRepositoryFqn = str_replace('\\Entities\\', '\\Entity\\', $entityFqn);
+        $entityRepositoryFqn = str_replace('\\Entities\\', '\\Entity\\Repositories\\', $entityFqn);
 
         $entityRepositoryFqn .= 'Repository';
 
@@ -151,7 +151,12 @@ abstract class AbstractEntityTest extends TestCase implements EntityTestInterfac
     {
         $testedEntityRepositoryFqn = $this->getTestedEntityRepositoryFqn();
 
-        return new $testedEntityRepositoryFqn($this->entityValidatorFactory, ...$this->extraEntityDependencies());
+        return new $testedEntityRepositoryFqn(
+            $this->entityManager,
+            $this->namespaceHelper,
+            $this->entityValidatorFactory,
+            ...$this->extraEntityDependencies()
+        );
     }
 
     /**

--- a/src/Entity/Testing/AbstractEntityTest.php
+++ b/src/Entity/Testing/AbstractEntityTest.php
@@ -16,6 +16,7 @@ use EdmondsCommerce\DoctrineStaticMeta\Config;
 use EdmondsCommerce\DoctrineStaticMeta\ConfigInterface;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Embeddable\Objects\AbstractEmbeddableObject;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces\EntityInterface;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Repositories\EntityRepositoryInterface;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Savers\EntitySaver;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Savers\EntitySaverFactory;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Validation\EntityValidatorFactory;
@@ -86,6 +87,14 @@ abstract class AbstractEntityTest extends TestCase implements EntityTestInterfac
      * @var CodeHelper
      */
     protected $codeHelper;
+    /**
+     * @var NamespaceHelper
+     */
+    private $namespaceHelper;
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $entityRepository;
 
     /**
      * @throws ConfigException
@@ -108,7 +117,53 @@ abstract class AbstractEntityTest extends TestCase implements EntityTestInterfac
             $this->entitySaverFactory,
             $this->entityValidatorFactory
         );
-        $this->codeHelper             = new CodeHelper(new NamespaceHelper());
+        $this->namespaceHelper        = new NamespaceHelper();
+        $this->codeHelper             = new CodeHelper($this->namespaceHelper);
+        $this->entityRepository       = $this->getTestedEntityRepository();
+    }
+
+    /**
+     * Calculate the fully qualified name of the tested Entity's repository
+     *
+     * @return string
+     */
+    protected function getTestedEntityRepositoryFqn(): string
+    {
+        $entityFqn           = $this->getTestedEntityFqn();
+        $entityRepositoryFqn = str_replace('\\Entities\\', '\\Entity\\', $entityFqn);
+
+        $entityRepositoryFqn .= 'Repository';
+
+        return $entityRepositoryFqn;
+
+
+    }
+
+    /**
+     * Get an instance of the tested Entity's repository
+     *
+     * If the tested Entity requires extra dependencies then these are also injected. You need to override the
+     * `extraEntityDependencies` method to return instances of all required dependencies
+     *
+     * @return EntityRepositoryInterface
+     */
+    protected function getTestedEntityRepository(): EntityRepositoryInterface
+    {
+        $testedEntityRepositoryFqn = $this->getTestedEntityRepositoryFqn();
+
+        return new $testedEntityRepositoryFqn($this->entityValidatorFactory, ...$this->extraEntityDependencies());
+    }
+
+    /**
+     * Override this method in your test to provide instances of the extra dependencies your Entity requires
+     *
+     * The array must be correctly ordered
+     *
+     * @return array
+     */
+    protected function extraEntityDependencies(): array
+    {
+        return [];
     }
 
     /**
@@ -182,15 +237,13 @@ abstract class AbstractEntityTest extends TestCase implements EntityTestInterfac
 
 
     /**
-     * @param string        $class
-     * @param int|string    $id
-     * @param EntityManager $entityManager
+     * @param int|string $id
      *
      * @return EntityInterface|null
      */
-    protected function loadEntity(string $class, $id, EntityManager $entityManager): ?EntityInterface
+    protected function loadEntity($id): ?EntityInterface
     {
-        return $entityManager->getRepository($class)->find($id);
+        return $this->entityRepository->find($id);
     }
 
     public function testConstructor(): EntityInterface
@@ -361,9 +414,8 @@ abstract class AbstractEntityTest extends TestCase implements EntityTestInterfac
      */
     public function testLoadedEntity(EntityInterface $entity): EntityInterface
     {
-        $class         = $this->getTestedEntityFqn();
-        $entityManager = $this->getEntityManager();
-        $loaded        = $this->loadEntity($class, $entity->getId(), $entityManager);
+        $class  = $this->getTestedEntityFqn();
+        $loaded = $this->loadEntity($entity->getId());
         self::assertSame($entity->getId(), $loaded->getId());
         self::assertInstanceOf($class, $loaded);
         $this->updateEntityFields($loaded);
@@ -384,9 +436,7 @@ abstract class AbstractEntityTest extends TestCase implements EntityTestInterfac
      */
     public function testReloadedEntityHasNoAssociations(EntityInterface $entity): void
     {
-        $class         = $this->getTestedEntityFqn();
-        $entityManager = $this->getEntityManager();
-        $reLoaded      = $this->loadEntity($class, $entity->getId(), $entityManager);
+        $reLoaded = $this->loadEntity($entity->getId());
         self::assertEquals($entity->__toString(), $reLoaded->__toString());
         $this->assertAllAssociationsAreEmpty($reLoaded);
     }
@@ -435,7 +485,7 @@ abstract class AbstractEntityTest extends TestCase implements EntityTestInterfac
         $entityManager = $this->getEntityManager();
         $class         = $this->getTestedEntityFqn();
         $meta          = $entityManager->getClassMetadata($class);
-        $identifiers = array_flip($meta->getIdentifier());
+        $identifiers   = array_flip($meta->getIdentifier());
         foreach ($meta->getAssociationMappings() as $mapping) {
             if (isset($identifiers[$mapping['fieldName']])) {
                 continue;
@@ -459,7 +509,7 @@ abstract class AbstractEntityTest extends TestCase implements EntityTestInterfac
         $entityManager = $this->getEntityManager();
         $class         = $this->getTestedEntityFqn();
         $meta          = $entityManager->getClassMetadata($class);
-        $identifiers = array_flip($meta->getIdentifier());
+        $identifiers   = array_flip($meta->getIdentifier());
         foreach ($meta->getAssociationMappings() as $mapping) {
             if (isset($identifiers[$mapping['fieldName']])) {
                 continue;

--- a/tests/functional/Entity/Embeddable/Traits/Financial/HasMoneyEmbeddableTraitFunctionalTest.php
+++ b/tests/functional/Entity/Embeddable/Traits/Financial/HasMoneyEmbeddableTraitFunctionalTest.php
@@ -67,7 +67,7 @@ class HasMoneyEmbeddableTraitFunctionalTest extends AbstractFunctionalTest
         /**
          * @var AbstractEntityRepository $repo
          */
-        $repo   = $this->getEntityManager()->getRepository($this->entityFqn);
+        $repo   = $this->getEntityRepository($this->entityFqn);
         $loaded = $repo->findAll()[0];
 
         return $loaded;
@@ -123,7 +123,7 @@ class HasMoneyEmbeddableTraitFunctionalTest extends AbstractFunctionalTest
         /**
          * @var AbstractEntityRepository $repo
          */
-        $repo     = $this->getEntityManager()->getRepository($this->entityFqn);
+        $repo     = $this->getEntityRepository($this->entityFqn);
         $loaded   = $repo->findAll()[0];
         $expected = '100';
         $actual   = $loaded->getMoneyEmbeddable()->getMoney()->getAmount();

--- a/tests/functional/Entity/Embeddable/Traits/Geo/HasAddressEmbeddableTraitFunctionalTest.php
+++ b/tests/functional/Entity/Embeddable/Traits/Geo/HasAddressEmbeddableTraitFunctionalTest.php
@@ -44,8 +44,7 @@ class HasAddressEmbeddableTraitFunctionalTest extends AbstractFunctionalTest
 
         $this->getEntitySaver()->save($entity);
 
-        $loaded = $this->getEntityManager()
-                       ->getRepository($this->entityFqn)
+        $loaded = $this->getEntityRepository($this->entityFqn)
                        ->findAll()[0];
         self::assertSame($entity, $loaded);
     }

--- a/tests/functional/Entity/Embeddable/Traits/Identity/HasFullNameEmbeddableTraitFunctionalTest.php
+++ b/tests/functional/Entity/Embeddable/Traits/Identity/HasFullNameEmbeddableTraitFunctionalTest.php
@@ -46,8 +46,7 @@ class HasFullNameEmbeddableTraitFunctionalTest extends AbstractFunctionalTest
 
         $this->getEntitySaver()->save($entity);
 
-        $loaded = $this->getEntityManager()
-                       ->getRepository($this->entityFqn)
+        $loaded = $this->getEntityRepository($this->entityFqn)
                        ->findAll()[0];
         self::assertSame($entity, $loaded);
     }

--- a/tests/functional/Entity/Fields/Traits/AbstractFieldTraitFunctionalTest.php
+++ b/tests/functional/Entity/Fields/Traits/AbstractFieldTraitFunctionalTest.php
@@ -46,7 +46,7 @@ abstract class AbstractFieldTraitFunctionalTest extends AbstractFunctionalTest
      * @var Generator
      */
     protected static $fakerGenerator;
-    protected        $entitySuffix;
+    protected $entitySuffix;
 
     /**
      * @SuppressWarnings(PHPMD.StaticAccess)

--- a/tests/functional/Entity/Fields/Traits/AbstractFieldTraitFunctionalTest.php
+++ b/tests/functional/Entity/Fields/Traits/AbstractFieldTraitFunctionalTest.php
@@ -25,8 +25,8 @@ use Faker\Generator;
 abstract class AbstractFieldTraitFunctionalTest extends AbstractFunctionalTest
 {
     protected const TEST_ENTITY_FQN_BASE = self::TEST_PROJECT_ROOT_NAMESPACE
-                                           . '\\' . AbstractGenerator::ENTITIES_FOLDER_NAME
-                                           . '\\';
+                                           .'\\'.AbstractGenerator::ENTITIES_FOLDER_NAME
+                                           .'\\';
 
     protected const TEST_FIELD_FQN = 'Override Me';
 
@@ -46,7 +46,7 @@ abstract class AbstractFieldTraitFunctionalTest extends AbstractFunctionalTest
      * @var Generator
      */
     protected static $fakerGenerator;
-    protected $entitySuffix;
+    protected        $entitySuffix;
 
     /**
      * @SuppressWarnings(PHPMD.StaticAccess)
@@ -67,10 +67,10 @@ abstract class AbstractFieldTraitFunctionalTest extends AbstractFunctionalTest
     protected function generateCode()
     {
         $this->getEntityGenerator()
-             ->generateEntity(static::TEST_ENTITY_FQN_BASE . $this->entitySuffix);
+             ->generateEntity(static::TEST_ENTITY_FQN_BASE.$this->entitySuffix);
         $this->getFieldSetter()
              ->setEntityHasField(
-                 static::TEST_ENTITY_FQN_BASE . $this->entitySuffix,
+                 static::TEST_ENTITY_FQN_BASE.$this->entitySuffix,
                  static::TEST_FIELD_FQN
              );
     }
@@ -82,7 +82,7 @@ abstract class AbstractFieldTraitFunctionalTest extends AbstractFunctionalTest
     public function testCreateEntityWithField(): void
     {
         $this->setupCopiedWorkDir();
-        $entityFqn = $this->getCopiedFqn(static::TEST_ENTITY_FQN_BASE . $this->entitySuffix);
+        $entityFqn = $this->getCopiedFqn(static::TEST_ENTITY_FQN_BASE.$this->entitySuffix);
         $entity    = new $entityFqn($this->container->get(EntityValidatorFactory::class));
         $getter    = $this->getGetter($entity);
         self::assertTrue(\method_exists($entity, $getter));
@@ -90,8 +90,8 @@ abstract class AbstractFieldTraitFunctionalTest extends AbstractFunctionalTest
         self::assertSame(
             static::TEST_FIELD_DEFAULT,
             $value,
-            'The getter on a newly created entity returns ' . var_export($value, true)
-            . ' whereas the configured default value is ' . var_export(static::TEST_FIELD_DEFAULT, true)
+            'The getter on a newly created entity returns '.var_export($value, true)
+            .' whereas the configured default value is '.var_export(static::TEST_FIELD_DEFAULT, true)
         );
         if (false === static::HAS_SETTER) {
             return;
@@ -109,12 +109,12 @@ abstract class AbstractFieldTraitFunctionalTest extends AbstractFunctionalTest
     protected function getGetter(EntityInterface $entity): string
     {
         foreach (['get', 'is', 'has'] as $prefix) {
-            $method = $prefix . static::TEST_FIELD_PROP;
+            $method = $prefix.static::TEST_FIELD_PROP;
             if (\method_exists($entity, $method)) {
                 return $method;
             }
         }
-        throw new \RuntimeException('Failed finding a getter in ' . __METHOD__);
+        throw new \RuntimeException('Failed finding a getter in '.__METHOD__);
     }
 
     /**
@@ -126,7 +126,7 @@ abstract class AbstractFieldTraitFunctionalTest extends AbstractFunctionalTest
      */
     protected function setFakerValueForProperty(EntityInterface $entity)
     {
-        $setter        = 'set' . static::TEST_FIELD_PROP;
+        $setter        = 'set'.static::TEST_FIELD_PROP;
         $fakerProvider = $this->getFakerDataProvider();
         if ($fakerProvider instanceof FakerDataProviderInterface) {
             $setValue = $fakerProvider();
@@ -159,7 +159,7 @@ abstract class AbstractFieldTraitFunctionalTest extends AbstractFunctionalTest
                 );
                 break;
             default:
-                throw new \RuntimeException('Failed getting a data provider for the property type ' . $setParamType);
+                throw new \RuntimeException('Failed getting a data provider for the property type '.$setParamType);
         }
         $entity->$setter($setValue);
 
@@ -180,10 +180,9 @@ abstract class AbstractFieldTraitFunctionalTest extends AbstractFunctionalTest
     public function testCreateDatabaseSchema()
     {
         $this->setupCopiedWorkDirAndCreateDatabase();
-        $entityManager = $this->getEntityManager();
-        $entityFqn     = $this->getCopiedFqn(static::TEST_ENTITY_FQN_BASE . $this->entitySuffix);
-        $entity        = new $entityFqn($this->container->get(EntityValidatorFactory::class));
-        $setValue      = null;
+        $entityFqn = $this->getCopiedFqn(static::TEST_ENTITY_FQN_BASE.$this->entitySuffix);
+        $entity    = new $entityFqn($this->container->get(EntityValidatorFactory::class));
+        $setValue  = null;
         if (false !== static::HAS_SETTER) {
             $setValue = $this->setFakerValueForProperty($entity);
         }

--- a/tests/functional/Entity/Fields/Traits/AbstractFieldTraitFunctionalTest.php
+++ b/tests/functional/Entity/Fields/Traits/AbstractFieldTraitFunctionalTest.php
@@ -189,7 +189,7 @@ abstract class AbstractFieldTraitFunctionalTest extends AbstractFunctionalTest
         }
         $saver = $this->container->get(EntitySaver::class);
         $saver->save($entity);
-        $repository  = $entityManager->getRepository($entityFqn);
+        $repository  = $this->getEntityRepository($entityFqn);
         $entities    = $repository->findAll();
         $savedEntity = current($entities);
         $getter      = $this->getGetter($entity);

--- a/tests/functional/Entity/Fields/Traits/PrimaryKey/IdFieldTraitTest.php
+++ b/tests/functional/Entity/Fields/Traits/PrimaryKey/IdFieldTraitTest.php
@@ -38,7 +38,7 @@ class IdFieldTraitTest extends AbstractFieldTraitFunctionalTest
         $entity        = $this->createEntity($entityFqn);
         $saver         = $this->container->get(EntitySaver::class);
         $saver->save($entity);
-        $repository  = $entityManager->getRepository($entityFqn);
+        $repository  = $this->getEntityRepository($entityFqn);
         $entities    = $repository->findAll();
         $savedEntity = current($entities);
         $this->validateSavedEntity($savedEntity);

--- a/tests/functional/Entity/Fields/Traits/PrimaryKey/IdFieldTraitTest.php
+++ b/tests/functional/Entity/Fields/Traits/PrimaryKey/IdFieldTraitTest.php
@@ -33,7 +33,6 @@ class IdFieldTraitTest extends AbstractFieldTraitFunctionalTest
     public function testCreateDatabaseSchema()
     {
         $this->setupCopiedWorkDirAndCreateDatabase();
-        $entityManager = $this->getEntityManager();
         $entityFqn     = $this->getCopiedFqn(static::TEST_ENTITY_FQN_BASE . $this->entitySuffix);
         $entity        = $this->createEntity($entityFqn);
         $saver         = $this->container->get(EntitySaver::class);

--- a/tests/functional/Entity/Repositories/AbstractEntityRepositoryFunctionalTest.php
+++ b/tests/functional/Entity/Repositories/AbstractEntityRepositoryFunctionalTest.php
@@ -100,7 +100,7 @@ class AbstractEntityRepositoryFunctionalTest extends AbstractFunctionalTest
 
     protected function getRepository()
     {
-        return $this->getEntityManager()->getRepository($this->getCopiedFqn(self::TEST_ENTITY_FQN));
+        return $this->getEntityRepository($this->getCopiedFqn(self::TEST_ENTITY_FQN));
     }
 
     public function testFind(): void

--- a/tests/functional/Entity/Savers/AbstractEntitySpecificSaverTest.php
+++ b/tests/functional/Entity/Savers/AbstractEntitySpecificSaverTest.php
@@ -88,11 +88,11 @@ class AbstractEntitySpecificSaverTest extends AbstractFunctionalTest
             /**
              * @var AbstractEntityRepository $repo
              */
-            $repo   = $this->getEntityManager()->getRepository($entityFqn);
+            $repo   = $this->getEntityRepository($entityFqn);
             $loaded = $repo->findAll();
             self::assertSame($this->generatedEntities[$entityFqn], $loaded);
             $saver->removeAll($loaded);
-            $reLoaded = $this->getEntityManager()->getRepository($entityFqn)->findAll();
+            $reLoaded = $this->getEntityRepository($entityFqn)->findAll();
             self::assertSame([], $reLoaded);
         }
     }
@@ -116,7 +116,7 @@ class AbstractEntitySpecificSaverTest extends AbstractFunctionalTest
         /**
          * @var AbstractEntityRepository $repo
          */
-        $repo   = $this->getEntityManager()->getRepository($entityFqn);
+        $repo   = $this->getEntityRepository($entityFqn);
         $loaded = $repo->findAll();
         foreach ($loaded as $entity) {
             $saver->remove($entity);
@@ -133,14 +133,14 @@ class AbstractEntitySpecificSaverTest extends AbstractFunctionalTest
             /**
              * @var AbstractEntityRepository $repo
              */
-            $repo                                = $this->getEntityManager()->getRepository($entityFqn);
+            $repo                                = $this->getEntityRepository($entityFqn);
             $loaded                              = $repo->findAll();
             $this->generatedEntities[$entityFqn] = $this->cloneEntities($loaded);
             foreach ($loaded as $entity) {
                 $entity->setName('name ' . microtime(true));
             }
             $saver->saveAll($loaded);
-            $reLoaded = $this->getEntityManager()->getRepository($entityFqn)->findAll();
+            $reLoaded = $this->getEntityRepository($entityFqn)->findAll();
             self::assertNotSame($this->generatedEntities[$entityFqn], $reLoaded);
         }
     }
@@ -162,7 +162,7 @@ class AbstractEntitySpecificSaverTest extends AbstractFunctionalTest
         /**
          * @var AbstractEntityRepository $repo
          */
-        $repo                                = $this->getEntityManager()->getRepository($entityFqn);
+        $repo                                = $this->getEntityRepository($entityFqn);
         $loaded                              = $repo->findAll();
         $this->generatedEntities[$entityFqn] = $this->cloneEntities($loaded);
         foreach ($loaded as $entity) {
@@ -171,7 +171,7 @@ class AbstractEntitySpecificSaverTest extends AbstractFunctionalTest
         foreach ($loaded as $entity) {
             $saver->save($entity);
         }
-        $reLoaded = $this->getEntityManager()->getRepository($entityFqn)->findAll();
+        $reLoaded = $this->getEntityRepository($entityFqn)->findAll();
         self::assertNotSame($this->generatedEntities[$entityFqn], $reLoaded);
     }
 }

--- a/tests/functional/Entity/Savers/EntitySaverFunctionalTest.php
+++ b/tests/functional/Entity/Savers/EntitySaverFunctionalTest.php
@@ -8,16 +8,16 @@ use EdmondsCommerce\DoctrineStaticMeta\MappingHelper;
 
 class EntitySaverFunctionalTest extends AbstractFunctionalTest
 {
-    public const WORK_DIR = AbstractIntegrationTest::VAR_PATH . '/' . self::TEST_TYPE . '/EntitySaverFunctionalTest';
+    public const WORK_DIR = AbstractIntegrationTest::VAR_PATH.'/'.self::TEST_TYPE.'/EntitySaverFunctionalTest';
 
     private const TEST_ENTITIES = [
-        self::TEST_PROJECT_ROOT_NAMESPACE . '\\Entities\\TestEntityOne',
-        self::TEST_PROJECT_ROOT_NAMESPACE . '\\Entities\\Deeply\\Nested\\TestEntityTwo',
+        self::TEST_PROJECT_ROOT_NAMESPACE.'\\Entities\\TestEntityOne',
+        self::TEST_PROJECT_ROOT_NAMESPACE.'\\Entities\\Deeply\\Nested\\TestEntityTwo',
     ];
 
     private const TEST_FIELDS = [
-        self::TEST_PROJECT_ROOT_NAMESPACE . '\\Entity\\Fields\\Traits\\NameFieldTrait',
-        self::TEST_PROJECT_ROOT_NAMESPACE . '\\Entity\\Fields\\Traits\\FooFieldTrait',
+        self::TEST_PROJECT_ROOT_NAMESPACE.'\\Entity\\Fields\\Traits\\NameFieldTrait',
+        self::TEST_PROJECT_ROOT_NAMESPACE.'\\Entity\\Fields\\Traits\\FooFieldTrait',
     ];
 
     public function setup()
@@ -54,9 +54,7 @@ class EntitySaverFunctionalTest extends AbstractFunctionalTest
 
     protected function findAllEntity(string $entityFqn): array
     {
-        $entityManager = $this->getEntityManager();
-
-        return $entityManager->getRepository($entityFqn)->findAll();
+        return $this->getEntityRepository($entityFqn)->findAll();
     }
 
     public function testItCanSaveAndRemoveMultipleEntities(): void
@@ -65,9 +63,9 @@ class EntitySaverFunctionalTest extends AbstractFunctionalTest
         foreach (self::TEST_ENTITIES as $entityFqn) {
             $entityFqn = $this->getCopiedFqn($entityFqn);
             foreach (range(0, 9) as $num) {
-                $entities[$entityFqn . $num] = $this->createEntity($entityFqn);
-                $entities[$entityFqn . $num]->setName('blah');
-                $entities[$entityFqn . $num]->setfoo('bar');
+                $entities[$entityFqn.$num] = $this->createEntity($entityFqn);
+                $entities[$entityFqn.$num]->setName('blah');
+                $entities[$entityFqn.$num]->setfoo('bar');
             }
         }
         $saver = $this->getEntitySaver();
@@ -77,8 +75,8 @@ class EntitySaverFunctionalTest extends AbstractFunctionalTest
             $loaded    = $this->findAllEntity($entityFqn);
             self::assertCount(10, $loaded);
             foreach (range(0, 9) as $num) {
-                self::assertSame($entities[$entityFqn . $num]->getName(), $loaded[$num]->getName());
-                self::assertSame($entities[$entityFqn . $num]->getFoo(), $loaded[$num]->getFoo());
+                self::assertSame($entities[$entityFqn.$num]->getName(), $loaded[$num]->getName());
+                self::assertSame($entities[$entityFqn.$num]->getFoo(), $loaded[$num]->getFoo());
             }
         }
 

--- a/tests/functional/FullProjectBuildFunctionalTest.php
+++ b/tests/functional/FullProjectBuildFunctionalTest.php
@@ -384,8 +384,7 @@ EOF
         $composerJson = <<<JSON
 {
   "require": {
-    "edmondscommerce/doctrine-static-meta": "dev-%s",
-    "edmondscommerce/typesafe-functions": "dev-master@dev"
+    "edmondscommerce/doctrine-static-meta": "dev-%s"
   },
   "repositories": [
     {

--- a/tests/integration/AbstractIntegrationTest.php
+++ b/tests/integration/AbstractIntegrationTest.php
@@ -19,6 +19,8 @@ use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\NamespaceHelper;
 use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\PathHelper;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Factory\EntityFactory;
 use EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces\EntityInterface;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Repositories\EntityRepositoryInterface;
+use EdmondsCommerce\DoctrineStaticMeta\Entity\Validation\EntityValidatorFactory;
 use EdmondsCommerce\DoctrineStaticMeta\Schema\Schema;
 use EdmondsCommerce\PHPQA\Constants;
 use PHPUnit\Framework\TestCase;
@@ -34,7 +36,7 @@ use Symfony\Component\Filesystem\Filesystem;
 abstract class AbstractIntegrationTest extends TestCase
 {
     public const TEST_TYPE                   = 'integration';
-    public const VAR_PATH                    = __DIR__ . '/../../var/testOutput/';
+    public const VAR_PATH                    = __DIR__.'/../../var/testOutput/';
     public const WORK_DIR                    = 'override me';
     public const TEST_PROJECT_ROOT_NAMESPACE = 'My\\IntegrationTest\\Project';
 
@@ -84,33 +86,33 @@ abstract class AbstractIntegrationTest extends TestCase
         if (false !== stripos(static::WORK_DIR, self::WORK_DIR)) {
             throw new \RuntimeException(
                 "You must set a `public const WORK_DIR=AbstractTest::VAR_PATH.'/'"
-                . ".self::TEST_TYPE.'/folderName/';` in your test class"
+                .".self::TEST_TYPE.'/folderName/';` in your test class"
             );
         }
         if (false === strpos(static::WORK_DIR, static::TEST_TYPE)) {
             throw new \RuntimeException(
                 'Your WORK_DIR is missing the test type, should look like: '
-                . "`public const WORK_DIR=AbstractTest::VAR_PATH.'/'"
-                . ".self::TEST_TYPE.'/folderName/';` in your test class"
+                ."`public const WORK_DIR=AbstractTest::VAR_PATH.'/'"
+                .".self::TEST_TYPE.'/folderName/';` in your test class"
             );
         }
         $this->copiedWorkDir       = null;
         $this->copiedRootNamespace = null;
         $this->entitiesPath        = static::WORK_DIR
-                                     . '/' . AbstractCommand::DEFAULT_SRC_SUBFOLDER
-                                     . '/' . AbstractGenerator::ENTITIES_FOLDER_NAME;
+                                     .'/'.AbstractCommand::DEFAULT_SRC_SUBFOLDER
+                                     .'/'.AbstractGenerator::ENTITIES_FOLDER_NAME;
         $this->getFileSystem()->mkdir($this->entitiesPath);
         $this->entitiesPath        = realpath($this->entitiesPath);
         $this->entityRelationsPath = static::WORK_DIR
-                                     . '/' . AbstractCommand::DEFAULT_SRC_SUBFOLDER
-                                     . '/' . AbstractGenerator::ENTITY_RELATIONS_FOLDER_NAME;
+                                     .'/'.AbstractCommand::DEFAULT_SRC_SUBFOLDER
+                                     .'/'.AbstractGenerator::ENTITY_RELATIONS_FOLDER_NAME;
         $this->getFileSystem()->mkdir($this->entityRelationsPath);
         $this->entityRelationsPath = realpath($this->entityRelationsPath);
         $this->setupContainer($this->entitiesPath);
         $this->clearWorkDir();
         $this->extendAutoloader(
-            static::TEST_PROJECT_ROOT_NAMESPACE . '\\',
-            static::WORK_DIR . '/' . AbstractCommand::DEFAULT_SRC_SUBFOLDER
+            static::TEST_PROJECT_ROOT_NAMESPACE.'\\',
+            static::WORK_DIR.'/'.AbstractCommand::DEFAULT_SRC_SUBFOLDER
         );
     }
 
@@ -135,7 +137,7 @@ abstract class AbstractIntegrationTest extends TestCase
      */
     protected function setupContainer(string $entitiesPath): void
     {
-        SimpleEnv::setEnv(Config::getProjectRootDirectory() . '/.env');
+        SimpleEnv::setEnv(Config::getProjectRootDirectory().'/.env');
         $testConfig                                       = $_SERVER;
         $testConfig[ConfigInterface::PARAM_ENTITIES_PATH] = $entitiesPath;
         $testConfig[ConfigInterface::PARAM_DB_NAME]       .= '_test';
@@ -186,7 +188,7 @@ abstract class AbstractIntegrationTest extends TestCase
             }
         }
         //Then build a new extension and register it
-        $namespace  = rtrim($namespace, '\\') . '\\';
+        $namespace  = rtrim($namespace, '\\').'\\';
         $testLoader = new class($namespace) extends ClassLoader
         {
             /**
@@ -271,11 +273,11 @@ abstract class AbstractIntegrationTest extends TestCase
     protected function setupCopiedWorkDir(): string
     {
         $copiedNamespaceRoot       = $this->getCopiedNamespaceRoot();
-        $this->copiedWorkDir       = rtrim(static::WORK_DIR, '/') . 'Copies/' . $copiedNamespaceRoot . '/';
+        $this->copiedWorkDir       = rtrim(static::WORK_DIR, '/').'Copies/'.$copiedNamespaceRoot.'/';
         $this->copiedRootNamespace = $copiedNamespaceRoot;
         if (is_dir($this->copiedWorkDir)) {
             throw new \RuntimeException(
-                'The Copied WorkDir ' . $this->copiedWorkDir . ' Already Exists'
+                'The Copied WorkDir '.$this->copiedWorkDir.' Already Exists'
             );
         }
         $this->filesystem->mkdir($this->copiedWorkDir);
@@ -305,17 +307,17 @@ abstract class AbstractIntegrationTest extends TestCase
 
             $updated = \preg_replace(
                 '%(use|namespace)\s+?'
-                . $this->container->get(FindAndReplaceHelper::class)
-                                  ->escapeSlashesForRegex(static::TEST_PROJECT_ROOT_NAMESPACE)
-                . '\\\\%',
-                '$1 ' . $copiedNamespaceRoot . '\\',
+                .$this->container->get(FindAndReplaceHelper::class)
+                                 ->escapeSlashesForRegex(static::TEST_PROJECT_ROOT_NAMESPACE)
+                .'\\\\%',
+                '$1 '.$copiedNamespaceRoot.'\\',
                 $contents
             );
             file_put_contents($info->getPathname(), $updated);
         }
         $this->extendAutoloader(
-            $this->copiedRootNamespace . '\\',
-            $this->copiedWorkDir . '/' . AbstractCommand::DEFAULT_SRC_SUBFOLDER
+            $this->copiedRootNamespace.'\\',
+            $this->copiedWorkDir.'/'.AbstractCommand::DEFAULT_SRC_SUBFOLDER
         );
 
         return $this->copiedWorkDir;
@@ -329,7 +331,7 @@ abstract class AbstractIntegrationTest extends TestCase
      */
     protected function getCopiedNamespaceRoot(): string
     {
-        return (new  \ts\Reflection\ReflectionClass(static::class))->getShortName() . '_' . $this->getName() . '_';
+        return (new  \ts\Reflection\ReflectionClass(static::class))->getShortName().'_'.$this->getName().'_';
     }
 
     /**
@@ -347,8 +349,8 @@ abstract class AbstractIntegrationTest extends TestCase
 
         return $this->container
             ->get(NamespaceHelper::class)
-            ->tidy('\\' . $copiedNamespaceRoot . '\\'
-                   . ltrim(
+            ->tidy('\\'.$copiedNamespaceRoot.'\\'
+                   .ltrim(
                        \str_replace(static::TEST_PROJECT_ROOT_NAMESPACE, '', $fqn),
                        '\\'
                    ));
@@ -392,9 +394,9 @@ abstract class AbstractIntegrationTest extends TestCase
         $checkFor[] = 'template';
         foreach ($checkFor as $check) {
             self::assertNotRegExp(
-                '%[^a-z]' . $check . '[^a-z]%i',
+                '%[^a-z]'.$check.'[^a-z]%i',
                 $contents,
-                'Found the word "' . $check . '" (case insensitive) in the created file ' . $createdFile
+                'Found the word "'.$check.'" (case insensitive) in the created file '.$createdFile
             );
         }
     }
@@ -469,6 +471,25 @@ abstract class AbstractIntegrationTest extends TestCase
     protected function getEntityManager(): EntityManager
     {
         return $this->container->get(EntityManagerInterface::class);
+    }
+
+    protected function getEntityRepository(string $entityFqn): EntityRepositoryInterface
+    {
+        static $loaded;
+        $entityRepositoryFqn = str_replace('\\Entities\\', '\\Entity\\Repositories\\', $entityFqn);
+
+        $entityRepositoryFqn .= 'Repository';
+        if (isset($loaded[$entityRepositoryFqn])) {
+            return $loaded[$entityRepositoryFqn];
+        }
+
+        $loaded[$entityRepositoryFqn] = new $entityRepositoryFqn(
+            $this->getEntityManager(),
+            $this->container->get(NamespaceHelper::class),
+            $this->container->get(EntityValidatorFactory::class)
+        );
+
+        return $loaded[$entityRepositoryFqn];
     }
 
     protected function getSchema(): Schema

--- a/tests/integration/AbstractIntegrationTest.php
+++ b/tests/integration/AbstractIntegrationTest.php
@@ -475,13 +475,13 @@ abstract class AbstractIntegrationTest extends TestCase
 
     protected function getEntityRepository(string $entityFqn): EntityRepositoryInterface
     {
-        static $loaded;
+//        static $loaded;
         $entityRepositoryFqn = str_replace('\\Entities\\', '\\Entity\\Repositories\\', $entityFqn);
 
         $entityRepositoryFqn .= 'Repository';
-        if (isset($loaded[$entityRepositoryFqn])) {
-            return $loaded[$entityRepositoryFqn];
-        }
+//        if (isset($loaded[$entityRepositoryFqn])) {
+//            return $loaded[$entityRepositoryFqn];
+//        }
 
         $loaded[$entityRepositoryFqn] = new $entityRepositoryFqn(
             $this->getEntityManager(),

--- a/tests/integration/CodeGeneration/Generator/EntityGeneratorIntegrationTest.php
+++ b/tests/integration/CodeGeneration/Generator/EntityGeneratorIntegrationTest.php
@@ -51,7 +51,7 @@ class EntityGeneratorIntegrationTest extends AbstractIntegrationTest
         $this->setupCopiedWorkDir();
 
         $entityManager = $this->getEntityManager();
-        $repository    = $entityManager->getRepository($this->getCopiedFqn($entityFqn));
+        $repository    = $this->getEntityRepository($this->getCopiedFqn($entityFqn));
         self::assertInstanceOf($this->getCopiedFqn($repositoryFqn), $repository);
     }
 

--- a/tests/integration/CodeGeneration/Generator/EntityGeneratorIntegrationTest.php
+++ b/tests/integration/CodeGeneration/Generator/EntityGeneratorIntegrationTest.php
@@ -8,26 +8,26 @@ use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\NamespaceHelper;
 
 class EntityGeneratorIntegrationTest extends AbstractIntegrationTest
 {
-    public const WORK_DIR = AbstractIntegrationTest::VAR_PATH . '/' . self::TEST_TYPE . '/EntityGeneratorTest/';
+    public const WORK_DIR = AbstractIntegrationTest::VAR_PATH.'/'.self::TEST_TYPE.'/EntityGeneratorTest/';
 
     /**
      */
     public function testGenerateEntity(): void
     {
         $fqn = static::TEST_PROJECT_ROOT_NAMESPACE
-               . '\\' . AbstractGenerator::ENTITIES_FOLDER_NAME
-               . '\\Yet\\Another\\TestEntity';
+               .'\\'.AbstractGenerator::ENTITIES_FOLDER_NAME
+               .'\\Yet\\Another\\TestEntity';
         $this->getEntityGenerator()->generateEntity($fqn);
         $createdFile = static::WORK_DIR
-                       . '/' . AbstractCommand::DEFAULT_SRC_SUBFOLDER
-                       . '/' . AbstractGenerator::ENTITIES_FOLDER_NAME
-                       . '/Yet/Another/TestEntity.php';
+                       .'/'.AbstractCommand::DEFAULT_SRC_SUBFOLDER
+                       .'/'.AbstractGenerator::ENTITIES_FOLDER_NAME
+                       .'/Yet/Another/TestEntity.php';
         $this->assertNoMissedReplacements($createdFile);
 
         $createdFile = static::WORK_DIR
-                       . '/' . AbstractCommand::DEFAULT_SRC_SUBFOLDER
-                       . '/' . AbstractGenerator::ENTITY_REPOSITORIES_FOLDER_NAME
-                       . '/Yet/Another/TestEntityRepository.php';
+                       .'/'.AbstractCommand::DEFAULT_SRC_SUBFOLDER
+                       .'/'.AbstractGenerator::ENTITY_REPOSITORIES_FOLDER_NAME
+                       .'/Yet/Another/TestEntityRepository.php';
         $this->assertNoMissedReplacements($createdFile);
         $this->qaGeneratedCode();
     }
@@ -36,22 +36,22 @@ class EntityGeneratorIntegrationTest extends AbstractIntegrationTest
      * Ensure we create the correct custom repository and also that Doctrine is properly configured to use it
      *
      * @throws \EdmondsCommerce\DoctrineStaticMeta\Exception\DoctrineStaticMetaException
+     * @throws \ReflectionException
      */
     public function testGenerateRepository(): void
     {
         $entityFqn = static::TEST_PROJECT_ROOT_NAMESPACE
-                     . '\\' . AbstractGenerator::ENTITIES_FOLDER_NAME
-                     . '\\Some\\Other\\TestEntity';
+                     .'\\'.AbstractGenerator::ENTITIES_FOLDER_NAME
+                     .'\\Some\\Other\\TestEntity';
 
-        $repositoryFqn = '\\' . static::TEST_PROJECT_ROOT_NAMESPACE
-                         . AbstractGenerator::ENTITY_REPOSITORIES_NAMESPACE
-                         . '\\Some\\Other\\TestEntityRepository';
+        $repositoryFqn = '\\'.static::TEST_PROJECT_ROOT_NAMESPACE
+                         .AbstractGenerator::ENTITY_REPOSITORIES_NAMESPACE
+                         .'\\Some\\Other\\TestEntityRepository';
 
         $this->getEntityGenerator()->generateEntity($entityFqn);
         $this->setupCopiedWorkDir();
 
-        $entityManager = $this->getEntityManager();
-        $repository    = $this->getEntityRepository($this->getCopiedFqn($entityFqn));
+        $repository = $this->getEntityRepository($this->getCopiedFqn($entityFqn));
         self::assertInstanceOf($this->getCopiedFqn($repositoryFqn), $repository);
     }
 
@@ -66,13 +66,13 @@ class EntityGeneratorIntegrationTest extends AbstractIntegrationTest
         $generator     = $this->getEntityGenerator()
                               ->setProjectRootNamespace($namespaceRoot);
         $entityFqnDeep = $namespaceRoot
-                         . '\\' . AbstractGenerator::ENTITIES_FOLDER_NAME
-                         . '\\Some\\Other\\TestEntity';
+                         .'\\'.AbstractGenerator::ENTITIES_FOLDER_NAME
+                         .'\\Some\\Other\\TestEntity';
         $generator->generateEntity($entityFqnDeep);
 
         $entityFqnRoot = $namespaceRoot
-                         . '\\' . AbstractGenerator::ENTITIES_FOLDER_NAME
-                         . '\\RootLevelEntity';
+                         .'\\'.AbstractGenerator::ENTITIES_FOLDER_NAME
+                         .'\\RootLevelEntity';
         $generator->generateEntity($entityFqnRoot);
 
         self::assertTrue($this->qaGeneratedCode($namespaceRoot));
@@ -81,30 +81,30 @@ class EntityGeneratorIntegrationTest extends AbstractIntegrationTest
 
     public function testGenerateEntityWithDeepNesting(): void
     {
-        $entityNamespace          = static::TEST_PROJECT_ROOT_NAMESPACE . '\\'
-                                    . AbstractGenerator::ENTITIES_FOLDER_NAME
-                                    . '\\Human\\Head\\Eye';
-        $entityFullyQualifiedName = $entityNamespace . '\\Lash';
+        $entityNamespace          = static::TEST_PROJECT_ROOT_NAMESPACE.'\\'
+                                    .AbstractGenerator::ENTITIES_FOLDER_NAME
+                                    .'\\Human\\Head\\Eye';
+        $entityFullyQualifiedName = $entityNamespace.'\\Lash';
         $this->getEntityGenerator()
              ->setProjectRootNamespace(static::TEST_PROJECT_ROOT_NAMESPACE)
              ->generateEntity($entityFullyQualifiedName);
 
         $createdFile = static::WORK_DIR
-                       . '/' . AbstractCommand::DEFAULT_SRC_SUBFOLDER
-                       . '/' . AbstractGenerator::ENTITIES_FOLDER_NAME
-                       . '/Human/Head/Eye/Lash.php';
+                       .'/'.AbstractCommand::DEFAULT_SRC_SUBFOLDER
+                       .'/'.AbstractGenerator::ENTITIES_FOLDER_NAME
+                       .'/Human/Head/Eye/Lash.php';
         $this->assertNoMissedReplacements($createdFile);
         self::assertContains("namespace $entityNamespace;", file_get_contents($createdFile));
 
         $createdFile = static::WORK_DIR
-                       . '/' . AbstractCommand::DEFAULT_SRC_SUBFOLDER
-                       . '/' . AbstractGenerator::ENTITY_REPOSITORIES_FOLDER_NAME
-                       . '/Human/Head/Eye/LashRepository.php';
+                       .'/'.AbstractCommand::DEFAULT_SRC_SUBFOLDER
+                       .'/'.AbstractGenerator::ENTITY_REPOSITORIES_FOLDER_NAME
+                       .'/Human/Head/Eye/LashRepository.php';
         $this->assertNoMissedReplacements($createdFile);
         $entityFullyQualifiedName = $this->container->get(NamespaceHelper::class)->tidy(
-            static::TEST_PROJECT_ROOT_NAMESPACE . '\\'
-            . AbstractGenerator::ENTITY_REPOSITORIES_NAMESPACE
-            . '\\Human\\Head\\Eye'
+            static::TEST_PROJECT_ROOT_NAMESPACE.'\\'
+            .AbstractGenerator::ENTITY_REPOSITORIES_NAMESPACE
+            .'\\Human\\Head\\Eye'
         );
         self::assertContains("namespace $entityFullyQualifiedName;", file_get_contents($createdFile));
 

--- a/tests/integration/Entity/Repositories/AbstractEntityRepositoryIntegrationTest.php
+++ b/tests/integration/Entity/Repositories/AbstractEntityRepositoryIntegrationTest.php
@@ -4,19 +4,20 @@ namespace EdmondsCommerce\DoctrineStaticMeta\Entity\Repositories;
 
 use EdmondsCommerce\DoctrineStaticMeta\AbstractIntegrationTest;
 use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\Generator\AbstractGenerator;
+use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\NamespaceHelper;
 
 class AbstractEntityRepositoryIntegrationTest extends AbstractIntegrationTest
 {
-    public const WORK_DIR = AbstractIntegrationTest::VAR_PATH . '/' . self::TEST_TYPE . '/AbstractEntityRepositoryTest';
+    public const WORK_DIR = AbstractIntegrationTest::VAR_PATH.'/'.self::TEST_TYPE.'/AbstractEntityRepositoryTest';
 
     public function testLoadingWithoutMetaData(): void
     {
         $entityFqn     = static::TEST_PROJECT_ROOT_NAMESPACE
-                         . '\\' . AbstractGenerator::ENTITIES_FOLDER_NAME
-                         . '\\Yet\\Another\\TestEntity';
+                         .'\\'.AbstractGenerator::ENTITIES_FOLDER_NAME
+                         .'\\Yet\\Another\\TestEntity';
         $repositoryFqn = static::TEST_PROJECT_ROOT_NAMESPACE
-                         . '\\' . AbstractGenerator::ENTITY_REPOSITORIES_NAMESPACE
-                         . '\\Yet\\Another\\TestEntityRepository';
+                         .'\\'.AbstractGenerator::ENTITY_REPOSITORIES_NAMESPACE
+                         .'\\Yet\\Another\\TestEntityRepository';
         $this->getEntityGenerator()->generateEntity($entityFqn);
         $this->setupCopiedWorkDir();
         $entityFqn     = $this->getCopiedFqn($entityFqn);
@@ -24,7 +25,7 @@ class AbstractEntityRepositoryIntegrationTest extends AbstractIntegrationTest
         /**
          * @var AbstractEntityRepository $repository
          */
-        $repository = new $repositoryFqn($this->getEntityManager());
+        $repository = new $repositoryFqn($this->getEntityManager(), $this->container->get(NamespaceHelper::class));
         self::assertInstanceOf($repositoryFqn, $repository);
         $expected = ltrim($entityFqn, '\\');
         $actual   = $repository->getClassName();

--- a/tests/unit/Exception/ValidationExceptionTest.php
+++ b/tests/unit/Exception/ValidationExceptionTest.php
@@ -133,6 +133,11 @@ class ValidationExceptionTest extends TestCase
                 {
                     return;
                 }
+
+                public function injectDependencies(...$extraDependencies): void
+                {
+                    // TODO: Implement injectDependencies() method.
+                }
             };
             throw new ValidationException($this->errors, $this->entity);
         } catch (ValidationException $e) {


### PR DESCRIPTION
This branch means that Entities can have dependencies

Classic use case is to inject a LoggerInterface to allow you to log things

The issue is that Doctrine by default uses Reflection and does not call the constructor

These changes disable that functionality so that you have to DI or manually create your repositories. We already had each Entity having it's own custom repository

Then in your repository, you need to have all of the extra dependencies that your Entity needs so that they can be injected. 