### PR TITLE
Enforce return types on repositories

### DIFF
--- a/codeTemplates/src/Entity/Repositories/TemplateEntityRepository.php
+++ b/codeTemplates/src/Entity/Repositories/TemplateEntityRepository.php
@@ -3,7 +3,7 @@
 namespace TemplateNamespace\Entity\Repositories;
 
 use FQNFor\AbstractEntityRepository;
-use TemplateNamespace\Entity\Interfaces\TemplateEntityInterface;
+use TemplateNamespace\Entity\Interfaces;
 
 // phpcs:disable -- line length
 class TemplateEntityRepository extends AbstractEntityRepository

--- a/codeTemplates/src/Entity/Repositories/TemplateEntityRepository.php
+++ b/codeTemplates/src/Entity/Repositories/TemplateEntityRepository.php
@@ -3,8 +3,50 @@
 namespace TemplateNamespace\Entity\Repositories;
 
 use FQNFor\AbstractEntityRepository;
+use TemplateNamespace\Entity\Interfaces\TemplateEntityInterface;
+
 // phpcs:disable -- line length
 class TemplateEntityRepository extends AbstractEntityRepository
 {
 // phpcs: enable
+
+    public function find($id, ?int $lockMode = null, ?int $lockVersion = null): ?TemplateEntityInterface
+    {
+        $result = parent::find($id, $lockMode, $lockVersion);
+        if ($result === null || $result instanceof TemplateEntityInterface) {
+            return $result;
+        }
+
+        throw new \RuntimeException('Unknown entity type of ' . get_class($result) . ' returned');
+    }
+
+    public function findOneBy(array $criteria, ?array $orderBy = null): ?TemplateEntityInterface
+    {
+        $result = parent::findOneBy($criteria, $orderBy);
+        if ($result === null || $result instanceof TemplateEntityInterface) {
+            return $result;
+        }
+
+        throw new \RuntimeException('Unknown entity type of ' . get_class($result) . ' returned');
+    }
+
+    public function get($id, ?int $lockMode = null, ?int $lockVersion = null): TemplateEntityInterface
+    {
+        $result = $this->find($id, $lockMode, $lockVersion);
+        if ($result === null) {
+            throw new \RuntimeException('Could not find the entity');
+        }
+
+        return $result;
+    }
+
+    public function getOneBy(array $criteria, ?array $orderBy = null): TemplateEntityInterface
+    {
+        $result = $this->findOneBy($criteria, $orderBy);
+        if ($result === null) {
+            throw new \RuntimeException('Could not find the entity');
+        }
+
+        return $result;
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -711,16 +711,16 @@
         },
         {
             "name": "doctrine/persistence",
-            "version": "v1.0.0",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "17896f6d56a2794a1619e019596ae627aabd8fd5"
+                "reference": "af1ec238659a83e320f03e0e454e200f689b4b97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/17896f6d56a2794a1619e019596ae627aabd8fd5",
-                "reference": "17896f6d56a2794a1619e019596ae627aabd8fd5",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/af1ec238659a83e320f03e0e454e200f689b4b97",
+                "reference": "af1ec238659a83e320f03e0e454e200f689b4b97",
                 "shasum": ""
             },
             "require": {
@@ -785,7 +785,7 @@
             "keywords": [
                 "persistence"
             ],
-            "time": "2018-06-14T18:57:48+00:00"
+            "time": "2018-07-12T12:37:50+00:00"
         },
         {
             "name": "doctrine/reflection",

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
     "content-hash": "3b0e0c30be9dbc570f80a539acad74b0",
@@ -868,12 +868,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/edmondscommerce/typesafe-functions.git",
-                "reference": "2267a57c003457c82b2322d687f1df9c8efb09e0"
+                "reference": "d6c523847a878bedbf34d06fd0a182ce62f2028a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/edmondscommerce/typesafe-functions/zipball/2267a57c003457c82b2322d687f1df9c8efb09e0",
-                "reference": "2267a57c003457c82b2322d687f1df9c8efb09e0",
+                "url": "https://api.github.com/repos/edmondscommerce/typesafe-functions/zipball/d6c523847a878bedbf34d06fd0a182ce62f2028a",
+                "reference": "d6c523847a878bedbf34d06fd0a182ce62f2028a",
                 "shasum": ""
             },
             "require": {
@@ -899,7 +899,7 @@
                 "MIT"
             ],
             "description": "Type safe wrappers around internal functions that return mixed types",
-            "time": "2018-07-31T14:41:42+00:00"
+            "time": "2018-08-23T14:02:13+00:00"
         },
         {
             "name": "gossi/docblock",
@@ -2356,16 +2356,16 @@
         },
         {
             "name": "edmondscommerce/phpqa",
-            "version": "1.2.5",
+            "version": "1.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/edmondscommerce/phpqa.git",
-                "reference": "65405e3519d5804ea6b47b1fb264653457d74e0f"
+                "reference": "9a8678f783d77e4ac37d4101c95ccbf8ff5e9f8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/edmondscommerce/phpqa/zipball/65405e3519d5804ea6b47b1fb264653457d74e0f",
-                "reference": "65405e3519d5804ea6b47b1fb264653457d74e0f",
+                "url": "https://api.github.com/repos/edmondscommerce/phpqa/zipball/9a8678f783d77e4ac37d4101c95ccbf8ff5e9f8d",
+                "reference": "9a8678f783d77e4ac37d4101c95ccbf8ff5e9f8d",
                 "shasum": ""
             },
             "require": {
@@ -2409,7 +2409,7 @@
                 "MIT"
             ],
             "description": "Simple PHP QA pipeline and scripts. Largely just a collection of dependencies with configuration and scripts to run them together",
-            "time": "2018-08-23T10:55:03+00:00"
+            "time": "2018-08-23T17:55:31+00:00"
         },
         {
             "name": "funkyproject/reflection-file",

--- a/src/CodeGeneration/Generator/EntityGenerator.php
+++ b/src/CodeGeneration/Generator/EntityGenerator.php
@@ -210,10 +210,10 @@ class EntityGenerator extends AbstractGenerator
             );
             $classInterface = preg_replace('#Repository$#', 'Interface', $className);
 
+            $this->findAndReplaceHelper->replaceEntityInterfaceNamespace($classInterfaceNamespace, $filePath);
             $this->findAndReplaceHelper->replaceName($className, $filePath, self::FIND_ENTITY_NAME . 'Repository');
             $this->findAndReplaceHelper->replaceProjectNamespace($this->projectRootNamespace, $filePath);
             $this->findAndReplaceHelper->replaceEntityRepositoriesNamespace($namespace, $filePath);
-            $this->findAndReplaceHelper->replaceEntityInterfaceNamespace($classInterfaceNamespace, $filePath);
             $this->findAndReplaceHelper->replaceName($classInterface, $filePath, self::FIND_ENTITY_NAME . 'Interface');
             $this->findAndReplaceHelper->findReplace(
                 'use FQNFor\AbstractEntityRepository;',

--- a/src/CodeGeneration/Generator/EntityGenerator.php
+++ b/src/CodeGeneration/Generator/EntityGenerator.php
@@ -203,12 +203,17 @@ class EntityGenerator extends AbstractGenerator
                 $this->namespaceHelper->tidy($namespace),
                 $filePath
             );
+            $classInterfaceNamespace = \str_replace(
+                '\\' . AbstractGenerator::ENTITIES_FOLDER_NAME . '\\',
+                '\\' . AbstractGenerator::ENTITY_INTERFACE_NAMESPACE . '\\',
+                $entityFullyQualifiedName
+            );
             $classInterface = preg_replace('#Repository$#', 'Interface', $className);
 
             $this->findAndReplaceHelper->replaceName($className, $filePath, self::FIND_ENTITY_NAME . 'Repository');
             $this->findAndReplaceHelper->replaceProjectNamespace($this->projectRootNamespace, $filePath);
             $this->findAndReplaceHelper->replaceEntityRepositoriesNamespace($namespace, $filePath);
-            $this->findAndReplaceHelper->replaceEntityInterfaceNamespace($namespace, $filePath);
+            $this->findAndReplaceHelper->replaceEntityInterfaceNamespace($classInterfaceNamespace, $filePath);
             $this->findAndReplaceHelper->replaceName($classInterface, $filePath, self::FIND_ENTITY_NAME . 'Interface');
             $this->findAndReplaceHelper->findReplace(
                 'use FQNFor\AbstractEntityRepository;',

--- a/src/CodeGeneration/Generator/EntityGenerator.php
+++ b/src/CodeGeneration/Generator/EntityGenerator.php
@@ -203,10 +203,13 @@ class EntityGenerator extends AbstractGenerator
                 $this->namespaceHelper->tidy($namespace),
                 $filePath
             );
+            $classInterface = preg_replace('#Repository$#', 'Interface', $className);
 
             $this->findAndReplaceHelper->replaceName($className, $filePath, self::FIND_ENTITY_NAME . 'Repository');
             $this->findAndReplaceHelper->replaceProjectNamespace($this->projectRootNamespace, $filePath);
             $this->findAndReplaceHelper->replaceEntityRepositoriesNamespace($namespace, $filePath);
+            $this->findAndReplaceHelper->replaceEntityInterfaceNamespace($namespace, $filePath);
+            $this->findAndReplaceHelper->replaceName($classInterface, $filePath, self::FIND_ENTITY_NAME . 'Interface');
             $this->findAndReplaceHelper->findReplace(
                 'use FQNFor\AbstractEntityRepository;',
                 'use ' . $this->namespaceHelper->tidy(

--- a/src/CodeGeneration/Generator/EntityGenerator.php
+++ b/src/CodeGeneration/Generator/EntityGenerator.php
@@ -207,7 +207,7 @@ class EntityGenerator extends AbstractGenerator
                 '\\' . AbstractGenerator::ENTITIES_FOLDER_NAME . '\\',
                 '\\' . AbstractGenerator::ENTITY_INTERFACE_NAMESPACE . '\\',
                 $entityFullyQualifiedName
-            );
+            ) . 'Interface';
             $classInterface = preg_replace('#Repository$#', 'Interface', $className);
 
             $this->findAndReplaceHelper->replaceEntityInterfaceNamespace($classInterfaceNamespace, $filePath);

--- a/src/Entity/Repositories/AbstractEntityRepository.php
+++ b/src/Entity/Repositories/AbstractEntityRepository.php
@@ -97,7 +97,14 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
         );
     }
 
-    public function find($id, ?int $lockMode = null, ?int $lockVersion = null): ?EntityInterface
+    /**
+     * @param mixed    $id
+     * @param int|null $lockMode
+     * @param int|null $lockVersion
+     *
+     * @return EntityInterface|null
+     */
+    public function find($id, ?int $lockMode = null, ?int $lockVersion = null)
     {
         $entity = $this->entityRepository->find($id, $lockMode, $lockVersion);
         if (null === $entity || $entity instanceof EntityInterface) {
@@ -121,12 +128,51 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
         return $this->entityRepository->findBy($criteria, $orderBy, $limit, $offset);
     }
 
-    public function findOneBy(array $criteria, ?array $orderBy = null): ?EntityInterface
+    /**
+     * @param array      $criteria
+     * @param array|null $orderBy
+     *
+     * @return EntityInterface|null
+     */
+    public function findOneBy(array $criteria, ?array $orderBy = null)
     {
         $entity = $this->entityRepository->findOneBy($criteria, $orderBy);
         if (null === $entity || $entity instanceof EntityInterface) {
             return $entity;
         }
+    }
+
+    /**
+     * @param mixed    $id
+     * @param int|null $lockMode
+     * @param int|null $lockVersion
+     *
+     * @return EntityInterface
+     */
+    public function get($id, ?int $lockMode = null, ?int $lockVersion = null)
+    {
+        $entity = $this->find($id, $lockMode, $lockVersion);
+        if ($entity === null) {
+            throw new \RuntimeException('Could not find the entity');
+        }
+
+        return $entity;
+    }
+
+    /**
+     * @param array      $criteria
+     * @param array|null $orderBy
+     *
+     * @return EntityInterface
+     */
+    public function getOneBy(array $criteria, ?array $orderBy = null)
+    {
+        $result = $this->findOneBy($criteria, $orderBy);
+        if ($result === null) {
+            throw new \RuntimeException('Could not find the entity');
+        }
+
+        return $result;
     }
 
     public function getClassName(): string

--- a/src/Entity/Repositories/EntityRepositoryInterface.php
+++ b/src/Entity/Repositories/EntityRepositoryInterface.php
@@ -23,13 +23,43 @@ use EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces\EntityInterface;
  */
 interface EntityRepositoryInterface
 {
-    public function find($id, ?int $lockMode = null, ?int $lockVersion = null): ?EntityInterface;
+    /**
+     * @param mixed    $id
+     * @param int|null $lockMode
+     * @param int|null $lockVersion
+     *
+     * @return EntityInterface|null
+     */
+    public function find($id, ?int $lockMode = null, ?int $lockVersion = null);
 
     public function findAll(): array;
 
     public function findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null): array;
 
-    public function findOneBy(array $criteria, ?array $orderBy = null): ?EntityInterface;
+    /**
+     * @param array      $criteria
+     * @param array|null $orderBy
+     *
+     * @return EntityInterface|null
+     */
+    public function findOneBy(array $criteria, ?array $orderBy = null);
+
+    /**
+     * @param mixed    $id
+     * @param int|null $lockMode
+     * @param int|null $lockVersion
+     *
+     * @return EntityInterface
+     */
+    public function get($id, ?int $lockMode = null, ?int $lockVersion = null);
+
+    /**
+     * @param array      $criteria
+     * @param array|null $orderBy
+     *
+     * @return EntityInterface|null
+     */
+    public function getOneBy(array $criteria, ?array $orderBy = null);
 
     public function getClassName(): string;
 


### PR DESCRIPTION
Should generate these for all of the entities to prevent having to check
for the type each time something is fetched.

Also adding in get and getOneBy commands for when the entity is known to
exist to prevent having to check for null results. This will throw an
exception if nothing is found so use carefully