### PR TITLE
Force the class exists call not to autoload

### DIFF
--- a/src/Entity/Savers/EntitySaverFactory.php
+++ b/src/Entity/Savers/EntitySaverFactory.php
@@ -57,7 +57,7 @@ class EntitySaverFactory
     public function getSaverForEntityFqn(string $entityFqn): EntitySaverInterface
     {
         $saverFqn = $this->getSaverFqn($entityFqn);
-        if (class_exists($saverFqn)) {
+        if (class_exists($saverFqn, false)) {
             return new $saverFqn($this->entityManager, $this->namespaceHelper);
         }
 


### PR DESCRIPTION
As we are checking to see if the class exists we should avoid
autoloading it because it might not. This is required for proxies as
they throw Fatal Error Exceptions if the class is not where it is
expected to be