### PR TITLE
Standardise entity type hinting

### DIFF
--- a/codeTemplates/src/Entity/Factories/AbstractEntityFactory.php
+++ b/codeTemplates/src/Entity/Factories/AbstractEntityFactory.php
@@ -1,13 +1,10 @@
 <?php declare(strict_types=1);
 
 namespace TemplateNamespace\Entity\Repositories;
-
 // phpcs:disable -- line length
 use Doctrine\ORM\EntityManagerInterface;
 use EdmondsCommerce\DoctrineStaticMeta\Entity as DSM;
-
 // phpcs:enable
-
 /**
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */

--- a/codeTemplates/src/Entity/Factories/TemplateEntityFactory.php
+++ b/codeTemplates/src/Entity/Factories/TemplateEntityFactory.php
@@ -1,16 +1,13 @@
 <?php declare(strict_types=1);
 
 namespace TemplateNamespace\Entity\Factories;
-
+// phpcs:disable -- line length
 use FQNFor\AbstractEntityFactory;
 use EntityFqn;
 use TemplateNamespace\Entity\Interfaces;
-
-// phpcs:disable -- line length
+// phpcs: enable
 class TemplateEntityFactory extends AbstractEntityFactory
 {
-// phpcs: enable
-
     public function create(array $values = []): TemplateEntityInterface
     {
         return $this->entityFactory->create(TemplateEntity::class, $values);

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Interfaces/HasTemplateEntitiesInterface.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Interfaces/HasTemplateEntitiesInterface.php
@@ -4,8 +4,7 @@ namespace TemplateNamespace\Entity\Relations\TemplateEntity\Interfaces;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
-use EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces\UsesPHPMetaDataInterface;
-use TemplateNamespace\Entities\TemplateEntity as TemplateEntity;
+use TemplateNamespace\Entity\Interfaces\TemplateEntityInterface;
 
 interface HasTemplateEntitiesInterface
 {
@@ -19,38 +18,38 @@ interface HasTemplateEntitiesInterface
     public static function metaForTemplateEntities(ClassMetadataBuilder $builder): void;
 
     /**
-     * @return Collection|TemplateEntity[]
+     * @return Collection|TemplateEntityInterface[]
      */
     public function getTemplateEntities(): Collection;
 
     /**
-     * @param Collection|TemplateEntity[] $templateEntities
+     * @param Collection|TemplateEntityInterface[] $templateEntities
      *
      * @return self
      */
     public function setTemplateEntities(Collection $templateEntities): self;
 
     /**
-     * @param TemplateEntity|null $templateEntity
-     * @param bool                $recip
+     * @param TemplateEntityInterface|null $templateEntity
+     * @param bool                         $recip
      *
      * @return self
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
     public function addTemplateEntity(
-        ?TemplateEntity $templateEntity,
+        ?TemplateEntityInterface $templateEntity,
         bool $recip = true
     ): HasTemplateEntitiesInterface;
 
     /**
-     * @param TemplateEntity $templateEntity
+     * @param TemplateEntityInterface $templateEntity
      * @param bool           $recip
      *
      * @return self
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
     public function removeTemplateEntity(
-        TemplateEntity $templateEntity,
+        TemplateEntityInterface $templateEntity,
         bool $recip = true
     ): HasTemplateEntitiesInterface;
 

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Interfaces/HasTemplateEntityInterface.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Interfaces/HasTemplateEntityInterface.php
@@ -3,7 +3,7 @@
 namespace TemplateNamespace\Entity\Relations\TemplateEntity\Interfaces;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
-use TemplateNamespace\Entities\TemplateEntity as TemplateEntity;
+use TemplateNamespace\Entity\Interfaces\TemplateEntityInterface;
 
 interface HasTemplateEntityInterface
 {
@@ -17,32 +17,31 @@ interface HasTemplateEntityInterface
     public static function metaForTemplateEntity(ClassMetadataBuilder $builder): void;
 
     /**
-     * @return null|TemplateEntity
+     * @return null|TemplateEntityInterface
      */
-    public function getTemplateEntity(): ?TemplateEntity;
+    public function getTemplateEntity(): ?TemplateEntityInterface;
 
     /**
-     * @param TemplateEntity|null $templateEntity
-     * @param bool                $recip
+     * @param TemplateEntityInterface|null $templateEntity
+     * @param bool                         $recip
      *
      * @return self
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
     public function setTemplateEntity(
-        ?TemplateEntity $templateEntity,
+        ?TemplateEntityInterface $templateEntity,
         bool $recip = true
     ): HasTemplateEntityInterface;
 
     /**
-     * @param null|TemplateEntity $templateEntity
-     * @param bool                $recip
+     * @param null|TemplateEntityInterface $templateEntity
+     * @param bool                         $recip
      *
      * @return self
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
     public function removeTemplateEntity(
-        ?TemplateEntity $templateEntity = null,
+        ?TemplateEntityInterface $templateEntity = null,
         bool $recip = true
     ): HasTemplateEntityInterface;
-
 }

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Interfaces/ReciprocatesTemplateEntityInterface.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Interfaces/ReciprocatesTemplateEntityInterface.php
@@ -2,25 +2,25 @@
 
 namespace TemplateNamespace\Entity\Relations\TemplateEntity\Interfaces;
 
-use TemplateNamespace\Entities\TemplateEntity as TemplateEntity;
+use TemplateNamespace\Entity\Interfaces\TemplateEntityInterface;
 
 interface ReciprocatesTemplateEntityInterface
 {
     /**
-     * @param TemplateEntity $templateEntity
+     * @param TemplateEntityInterface $templateEntity
      *
      * @return self
      */
     public function reciprocateRelationOnTemplateEntity(
-        TemplateEntity $templateEntity
+        TemplateEntityInterface $templateEntity
     ): self;
 
     /**
-     * @param TemplateEntity $templateEntity
+     * @param TemplateEntityInterface $templateEntity
      *
      * @return self
      */
     public function removeRelationOnTemplateEntity(
-        TemplateEntity $templateEntity
+        TemplateEntityInterface $templateEntity
     ): self;
 }

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntities/HasTemplateEntitiesInverseManyToMany.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntities/HasTemplateEntitiesInverseManyToMany.php
@@ -29,25 +29,27 @@ trait HasTemplateEntitiesInverseManyToMany
      * @param ClassMetadataBuilder $builder
      *
      * @throws \EdmondsCommerce\DoctrineStaticMeta\Exception\DoctrineStaticMetaException
+     * @throws \ReflectionException
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public static function metaForTemplateEntities(
         ClassMetadataBuilder $builder
     ): void {
         $manyToManyBuilder = $builder->createManyToMany(
-            TemplateEntity::getDoctrineStaticMeta()->getPlural(), TemplateEntity::class
+            TemplateEntity::getDoctrineStaticMeta()->getPlural(),
+            TemplateEntity::class
         );
         $manyToManyBuilder->mappedBy(self::getDoctrineStaticMeta()->getPlural());
         $fromTableName = Inflector::tableize(TemplateEntity::getDoctrineStaticMeta()->getPlural());
         $toTableName   = Inflector::tableize(self::getDoctrineStaticMeta()->getPlural());
-        $manyToManyBuilder->setJoinTable($fromTableName.'_to_'.$toTableName);
+        $manyToManyBuilder->setJoinTable($fromTableName . '_to_' . $toTableName);
         $manyToManyBuilder->addJoinColumn(
-            Inflector::tableize(self::getDoctrineStaticMeta()->getSingular().'_'.static::PROP_ID),
+            Inflector::tableize(self::getDoctrineStaticMeta()->getSingular() . '_' . static::PROP_ID),
             static::PROP_ID
         );
         $manyToManyBuilder->addInverseJoinColumn(
             Inflector::tableize(
-                TemplateEntity::getDoctrineStaticMeta()->getSingular().'_'.TemplateEntity::PROP_ID
+                TemplateEntity::getDoctrineStaticMeta()->getSingular() . '_' . TemplateEntity::PROP_ID
             ),
             TemplateEntity::PROP_ID
         );

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntities/HasTemplateEntitiesOneToMany.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntities/HasTemplateEntitiesOneToMany.php
@@ -29,6 +29,7 @@ trait HasTemplateEntitiesOneToMany
      * @param ClassMetadataBuilder $builder
      *
      * @throws \EdmondsCommerce\DoctrineStaticMeta\Exception\DoctrineStaticMetaException
+     * @throws \ReflectionException
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public static function metaForTemplateEntities(

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntities/HasTemplateEntitiesOwningManyToMany.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntities/HasTemplateEntitiesOwningManyToMany.php
@@ -29,6 +29,7 @@ trait HasTemplateEntitiesOwningManyToMany
      * @param ClassMetadataBuilder $builder
      *
      * @throws \EdmondsCommerce\DoctrineStaticMeta\Exception\DoctrineStaticMetaException
+     * @throws \ReflectionException
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public static function metaForTemplateEntities(
@@ -36,19 +37,20 @@ trait HasTemplateEntitiesOwningManyToMany
     ): void {
 
         $manyToManyBuilder = $builder->createManyToMany(
-            TemplateEntity::getDoctrineStaticMeta()->getPlural(), TemplateEntity::class
+            TemplateEntity::getDoctrineStaticMeta()->getPlural(),
+            TemplateEntity::class
         );
         $manyToManyBuilder->inversedBy(self::getDoctrineStaticMeta()->getPlural());
         $fromTableName = Inflector::tableize(self::getDoctrineStaticMeta()->getPlural());
         $toTableName   = Inflector::tableize(TemplateEntity::getDoctrineStaticMeta()->getPlural());
-        $manyToManyBuilder->setJoinTable($fromTableName.'_to_'.$toTableName);
+        $manyToManyBuilder->setJoinTable($fromTableName . '_to_' . $toTableName);
         $manyToManyBuilder->addJoinColumn(
-            Inflector::tableize(self::getDoctrineStaticMeta()->getSingular().'_'.static::PROP_ID),
+            Inflector::tableize(self::getDoctrineStaticMeta()->getSingular() . '_' . static::PROP_ID),
             static::PROP_ID
         );
         $manyToManyBuilder->addInverseJoinColumn(
             Inflector::tableize(
-                TemplateEntity::getDoctrineStaticMeta()->getSingular().'_'.TemplateEntity::PROP_ID
+                TemplateEntity::getDoctrineStaticMeta()->getSingular() . '_' . TemplateEntity::PROP_ID
             ),
             TemplateEntity::PROP_ID
         );

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntitiesAbstract.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntitiesAbstract.php
@@ -7,7 +7,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Mapping\ClassMetadata as ValidatorClassMetaData;
-use TemplateNamespace\Entities\TemplateEntity as TemplateEntity;
+use TemplateNamespace\Entity\Interfaces\TemplateEntityInterface;
 use TemplateNamespace\Entity\Relations\TemplateEntity\Interfaces\HasTemplateEntitiesInterface;
 use TemplateNamespace\Entity\Relations\TemplateEntity\Interfaces\ReciprocatesTemplateEntityInterface;
 
@@ -22,7 +22,7 @@ use TemplateNamespace\Entity\Relations\TemplateEntity\Interfaces\ReciprocatesTem
 trait HasTemplateEntitiesAbstract
 {
     /**
-     * @var ArrayCollection|TemplateEntity[]
+     * @var ArrayCollection|TemplateEntityInterface[]
      */
     private $templateEntities;
 
@@ -52,7 +52,7 @@ trait HasTemplateEntitiesAbstract
     ): void;
 
     /**
-     * @return Collection|TemplateEntity[]
+     * @return Collection|TemplateEntityInterface[]
      */
     public function getTemplateEntities(): Collection
     {
@@ -60,7 +60,7 @@ trait HasTemplateEntitiesAbstract
     }
 
     /**
-     * @param Collection|TemplateEntity[] $templateEntities
+     * @param Collection|TemplateEntityInterface[] $templateEntities
      *
      * @return self
      */
@@ -76,14 +76,14 @@ trait HasTemplateEntitiesAbstract
     }
 
     /**
-     * @param TemplateEntity|null $templateEntity
-     * @param bool                $recip
+     * @param TemplateEntityInterface|null $templateEntity
+     * @param bool                         $recip
      *
      * @return self
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
     public function addTemplateEntity(
-        ?TemplateEntity $templateEntity,
+        ?TemplateEntityInterface $templateEntity,
         bool $recip = true
     ): HasTemplateEntitiesInterface {
         if ($templateEntity === null) {
@@ -101,14 +101,14 @@ trait HasTemplateEntitiesAbstract
     }
 
     /**
-     * @param TemplateEntity $templateEntity
-     * @param bool           $recip
+     * @param TemplateEntityInterface $templateEntity
+     * @param bool                    $recip
      *
      * @return self
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
     public function removeTemplateEntity(
-        TemplateEntity $templateEntity,
+        TemplateEntityInterface $templateEntity,
         bool $recip = true
     ): HasTemplateEntitiesInterface {
         $this->removeFromEntityCollectionAndNotify('templateEntities', $templateEntity);

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntity/HasTemplateEntityInverseOneToOne.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntity/HasTemplateEntityInverseOneToOne.php
@@ -29,6 +29,7 @@ trait HasTemplateEntityInverseOneToOne
      * @param ClassMetadataBuilder $builder
      *
      * @throws \EdmondsCommerce\DoctrineStaticMeta\Exception\DoctrineStaticMetaException
+     * @throws \ReflectionException
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public static function metaForTemplateEntity(

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntity/HasTemplateEntityManyToOne.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntity/HasTemplateEntityManyToOne.php
@@ -31,6 +31,7 @@ trait HasTemplateEntityManyToOne
      * @param ClassMetadataBuilder $builder
      *
      * @throws \EdmondsCommerce\DoctrineStaticMeta\Exception\DoctrineStaticMetaException
+     * @throws \ReflectionException
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public static function metaForTemplateEntity(

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntity/HasTemplateEntityOwningOneToOne.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntity/HasTemplateEntityOwningOneToOne.php
@@ -28,6 +28,7 @@ trait HasTemplateEntityOwningOneToOne
      * @param ClassMetadataBuilder $builder
      *
      * @throws \EdmondsCommerce\DoctrineStaticMeta\Exception\DoctrineStaticMetaException
+     * @throws \ReflectionException
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public static function metaForTemplateEntity(

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntity/HasTemplateEntityUnidirectionalManyToOne.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntity/HasTemplateEntityUnidirectionalManyToOne.php
@@ -27,6 +27,7 @@ trait HasTemplateEntityUnidirectionalManyToOne
      * @param ClassMetadataBuilder $builder
      *
      * @throws \EdmondsCommerce\DoctrineStaticMeta\Exception\DoctrineStaticMetaException
+     * @throws \ReflectionException
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public static function metaForTemplateEntity(

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntity/HasTemplateEntityUnidirectionalOneToOne.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntity/HasTemplateEntityUnidirectionalOneToOne.php
@@ -24,6 +24,7 @@ trait HasTemplateEntityUnidirectionalOneToOne
      * @param ClassMetadataBuilder $builder
      *
      * @throws \EdmondsCommerce\DoctrineStaticMeta\Exception\DoctrineStaticMetaException
+     * @throws \ReflectionException
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public static function metaForTemplateEntity(

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntityAbstract.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntityAbstract.php
@@ -7,6 +7,7 @@ use EdmondsCommerce\DoctrineStaticMeta\Entity\Interfaces\EntityInterface;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Mapping\ClassMetadata as ValidatorClassMetaData;
 use TemplateNamespace\Entities\TemplateEntity as TemplateEntity;
+use TemplateNamespace\Entity\Interfaces\TemplateEntityInterface;
 use TemplateNamespace\Entity\Relations\TemplateEntity\Interfaces\HasTemplateEntityInterface;
 use TemplateNamespace\Entity\Relations\TemplateEntity\Interfaces\ReciprocatesTemplateEntityInterface;
 
@@ -51,38 +52,6 @@ trait HasTemplateEntityAbstract
     }
 
     /**
-     * @return TemplateEntity|null
-     */
-    public function getTemplateEntity(): ?TemplateEntity
-    {
-        return $this->templateEntity;
-    }
-
-    /**
-     * @param TemplateEntity|null $templateEntity
-     * @param bool                $recip
-     *
-     * @return HasTemplateEntityInterface
-     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
-     */
-    public function setTemplateEntity(
-        ?TemplateEntity $templateEntity,
-        bool $recip = true
-    ): HasTemplateEntityInterface {
-
-        $this->setEntityAndNotify('templateEntity', $templateEntity);
-        if (
-            $this instanceof ReciprocatesTemplateEntityInterface
-            && true === $recip
-            && null !== $templateEntity
-        ) {
-            $this->reciprocateRelationOnTemplateEntity($templateEntity);
-        }
-
-        return $this;
-    }
-
-    /**
      * @param null|TemplateEntity $templateEntity
      * @param bool                $recip
      *
@@ -100,10 +69,42 @@ trait HasTemplateEntityAbstract
             if (!$templateEntity instanceof EntityInterface) {
                 $templateEntity = $this->getTemplateEntity();
             }
-            $remover = 'remove'.self::getDoctrineStaticMeta()->getSingular();
+            $remover = 'remove' . self::getDoctrineStaticMeta()->getSingular();
             $templateEntity->$remover($this, false);
         }
 
         return $this->setTemplateEntity(null, false);
+    }
+
+    /**
+     * @return TemplateEntityInterface|null
+     */
+    public function getTemplateEntity(): ?TemplateEntityInterface
+    {
+        return $this->templateEntity;
+    }
+
+    /**
+     * @param TemplateEntityInterface|null $templateEntity
+     * @param bool                         $recip
+     *
+     * @return HasTemplateEntityInterface
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     */
+    public function setTemplateEntity(
+        ?TemplateEntityInterface $templateEntity,
+        bool $recip = true
+    ): HasTemplateEntityInterface {
+
+        $this->setEntityAndNotify('templateEntity', $templateEntity);
+        if (
+            $this instanceof ReciprocatesTemplateEntityInterface
+            && true === $recip
+            && null !== $templateEntity
+        ) {
+            $this->reciprocateRelationOnTemplateEntity($templateEntity);
+        }
+
+        return $this;
     }
 }

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntityAbstract.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntityAbstract.php
@@ -52,14 +52,14 @@ trait HasTemplateEntityAbstract
     }
 
     /**
-     * @param null|TemplateEntity $templateEntity
-     * @param bool                $recip
+     * @param null|TemplateEntityInterface $templateEntity
+     * @param bool                         $recip
      *
      * @return HasTemplateEntityInterface
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
     public function removeTemplateEntity(
-        ?TemplateEntity $templateEntity = null,
+        ?TemplateEntityInterface $templateEntity = null,
         bool $recip = true
     ): HasTemplateEntityInterface {
         if (

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/ReciprocatesTemplateEntity.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/ReciprocatesTemplateEntity.php
@@ -4,6 +4,7 @@ namespace TemplateNamespace\Entity\Relations\TemplateEntity\Traits;
 
 // phpcs:disable
 use TemplateNamespace\Entities\TemplateEntity as TemplateEntity;
+use TemplateNamespace\Entity\Interfaces\TemplateEntityInterface;
 use TemplateNamespace\Entity\Relations\TemplateEntity\Interfaces\ReciprocatesTemplateEntityInterface;
 
 /**
@@ -28,7 +29,7 @@ trait ReciprocatesTemplateEntity
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public function reciprocateRelationOnTemplateEntity(
-        TemplateEntity $templateEntity
+        TemplateEntityInterface $templateEntity
     ): ReciprocatesTemplateEntityInterface {
         $singular = self::getDoctrineStaticMeta()->getSingular();
         $setters  = $templateEntity::getDoctrineStaticMeta()->getSetters();
@@ -67,12 +68,11 @@ trait ReciprocatesTemplateEntity
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public function removeRelationOnTemplateEntity(
-        TemplateEntity $templateEntity
+        TemplateEntityInterface $templateEntity
     ): ReciprocatesTemplateEntityInterface {
         $method = 'remove' . self::getDoctrineStaticMeta()->getSingular();
         $templateEntity->$method($this, false);
 
         return $this;
     }
-
 }

--- a/composer.lock
+++ b/composer.lock
@@ -3610,16 +3610,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.3.3",
+            "version": "7.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1bd5629cccfb2c0a9ef5474b4ff772349e1ec898"
+                "reference": "0356331bf62896dc56e3a15030b23b73f38b2935"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1bd5629cccfb2c0a9ef5474b4ff772349e1ec898",
-                "reference": "1bd5629cccfb2c0a9ef5474b4ff772349e1ec898",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0356331bf62896dc56e3a15030b23b73f38b2935",
+                "reference": "0356331bf62896dc56e3a15030b23b73f38b2935",
                 "shasum": ""
             },
             "require": {
@@ -3690,7 +3690,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-09-01T15:49:55+00:00"
+            "time": "2018-09-05T09:58:53+00:00"
         },
         {
             "name": "pimple/pimple",

--- a/src/CodeGeneration/Generator/AbstractGenerator.php
+++ b/src/CodeGeneration/Generator/AbstractGenerator.php
@@ -78,6 +78,8 @@ abstract class AbstractGenerator
 
     public const FIND_ENTITY_NAME = 'TemplateEntity';
 
+    public const FIND_ENTITY_INTERFACE_NAME = 'TemplateEntityInterface';
+
     public const FIND_ENTITY_NAME_PLURAL = 'TemplateEntities';
 
     public const FIND_PROJECT_NAMESPACE = 'TemplateNamespace';

--- a/src/CodeGeneration/Generator/Relations/GenerateRelationCodeForEntity.php
+++ b/src/CodeGeneration/Generator/Relations/GenerateRelationCodeForEntity.php
@@ -35,6 +35,11 @@ class GenerateRelationCodeForEntity
     /**
      * @var string
      */
+    private $entityInterfaceFqn;
+
+    /**
+     * @var string
+     */
     private $pathToProjectRoot;
     /**
      * @var string
@@ -119,6 +124,7 @@ class GenerateRelationCodeForEntity
      */
     private function initialiseVariables(): void
     {
+        $this->entityInterfaceFqn = $this->namespaceHelper->getEntityInterfaceFromEntityFqn($this->entityFqn);
         list($className, , $subDirs) = $this->namespaceHelper->parseFullyQualifiedName(
             $this->entityFqn,
             $this->srcSubFolderName,
@@ -222,6 +228,14 @@ class GenerateRelationCodeForEntity
             "use {$this->entityFqn}",
             $path
         );
+        $this->findAndReplaceHelper->findReplace(
+            'use ' .
+            RelationsGenerator::FIND_ENTITY_INTERFACE_NAMESPACE .
+            '\\' .
+            RelationsGenerator::FIND_ENTITY_INTERFACE_NAME,
+            "use {$this->entityInterfaceFqn}",
+            $path
+        );
         $this->findAndReplaceHelper->findReplaceRegex(
             '%use(.+?)Relations\\\TemplateEntity(.+?);%',
             'use ${1}Relations\\' . $this->singularNamespace . '${2};',
@@ -230,6 +244,21 @@ class GenerateRelationCodeForEntity
         $this->findAndReplaceHelper->findReplaceRegex(
             '%use(.+?)Relations\\\TemplateEntity(.+?);%',
             'use ${1}Relations\\' . $this->pluralNamespace . '${2};',
+            $path
+        );
+        $this->findAndReplaceHelper->findReplaceRegex(
+            '%(Has|Reciprocates)TemplateEntity%',
+            '${1}' . $this->singularNamespacedName,
+            $path
+        );
+        $this->findAndReplaceHelper->findReplaceRegex(
+            '%(Has|Reciprocates)TemplateEntities%',
+            '${1}' . $this->pluralNamespacedName,
+            $path
+        );
+        $this->findAndReplaceHelper->findReplace(
+            RelationsGenerator::FIND_ENTITY_INTERFACE_NAME,
+            $this->namespaceHelper->basename($this->entityInterfaceFqn),
             $path
         );
         $this->findAndReplaceHelper->replaceName($this->singularNamespacedName, $path);

--- a/tests/Assets/AbstractTest.php
+++ b/tests/Assets/AbstractTest.php
@@ -94,7 +94,7 @@ abstract class AbstractTest extends TestCase
      *
      * The order of these actions is critical
      */
-    public function setup()
+    public function setUp()
     {
         if (false !== stripos(static::WORK_DIR, self::WORK_DIR)) {
             throw new \RuntimeException(

--- a/tests/Large/Builder/BuilderTest.php
+++ b/tests/Large/Builder/BuilderTest.php
@@ -42,7 +42,7 @@ class BuilderTest extends AbstractTest
 
     public function setUp()
     {
-        parent::setup();
+        parent::setUp();
         if (true !== self::$built) {
             foreach (self::TEST_ENTITIES as $entityFqn) {
                 $this->getEntityGenerator()->generateEntity($entityFqn);

--- a/tests/Large/CodeGeneration/Command/GenerateFieldMultipleTimesTest.php
+++ b/tests/Large/CodeGeneration/Command/GenerateFieldMultipleTimesTest.php
@@ -42,7 +42,7 @@ class GenerateFieldMultipleTimesTest extends AbstractCommandTest
      */
     public function setup(): void
     {
-        parent::setup();
+        parent::setUp();
         $this->entityName     = $this->generateEntities();
         $generateCommand      = $this->container->get(GenerateFieldCommand::class);
         $this->fieldGenerator = $this->getCommandTester($generateCommand);

--- a/tests/Large/CodeGeneration/Generator/Embeddable/ArchetypeEmbeddableGeneratorTest.php
+++ b/tests/Large/CodeGeneration/Generator/Embeddable/ArchetypeEmbeddableGeneratorTest.php
@@ -28,7 +28,7 @@ class ArchetypeEmbeddableGeneratorTest extends AbstractTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         $this->getEntityGenerator()
              ->generateEntity(self::TEST_ENTITY_PRODUCT);
         $this->getFieldSetter()

--- a/tests/Large/CodeGeneration/Generator/Field/FieldGeneratorTest.php
+++ b/tests/Large/CodeGeneration/Generator/Field/FieldGeneratorTest.php
@@ -63,7 +63,7 @@ class FieldGeneratorTest extends AbstractTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         $this->getEntityGenerator()->generateEntity(self::TEST_ENTITY_CAR);
         $this->fieldGenerator    = $this->getFieldGenerator();
         $this->entityFieldSetter = $this->getFieldSetter();

--- a/tests/Large/CodeGeneration/Generator/FileCreationTransactionTest.php
+++ b/tests/Large/CodeGeneration/Generator/FileCreationTransactionTest.php
@@ -23,7 +23,7 @@ class FileCreationTransactionTest extends AbstractTest
      */
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         FileCreationTransaction::markTransactionSuccessful();
         foreach ([self::TEST_PATH_1, self::TEST_PATH_2] as $path) {
             file_put_contents($path, $path);

--- a/tests/Large/CodeGeneration/Generator/RelationsGeneratorTest.php
+++ b/tests/Large/CodeGeneration/Generator/RelationsGeneratorTest.php
@@ -186,7 +186,7 @@ class RelationsGeneratorTest extends AbstractTest
                     continue;
                 }
                 $this->copiedExtraSuffix = $hasType;
-                $this->setup();
+                $this->setUp();
 
                 $this->relationsGenerator->setEntityHasRelationToEntity(
                     $this->getCopiedFqn(self::TEST_ENTITY_BASKET),
@@ -243,7 +243,7 @@ class RelationsGeneratorTest extends AbstractTest
         $this->copiedRootNamespace = null;
     }
 
-    public function setup()
+    public function setUp()
     {
         parent::setUp();
         $this->entityGenerator    = $this->getEntityGenerator();

--- a/tests/Large/CodeGeneration/Generator/RelationsGeneratorTest.php
+++ b/tests/Large/CodeGeneration/Generator/RelationsGeneratorTest.php
@@ -174,8 +174,9 @@ class RelationsGeneratorTest extends AbstractTest
      * @large
      * @covers ::setEntityHasRelationToEntity
      * @throws \ReflectionException
+     * @throws DoctrineStaticMetaException
      */
-    public function testSetRelationsBetweenEntities(): void
+    public function setRelationsBetweenEntities(): void
     {
         $errors = [];
         foreach (RelationsGenerator::HAS_TYPES as $hasType) {
@@ -244,7 +245,7 @@ class RelationsGeneratorTest extends AbstractTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         $this->entityGenerator    = $this->getEntityGenerator();
         $this->relationsGenerator = $this->getRelationsGenerator();
         if (false === self::$built) {

--- a/tests/Large/CodeGeneration/NamespaceHelperTest.php
+++ b/tests/Large/CodeGeneration/NamespaceHelperTest.php
@@ -52,7 +52,7 @@ class NamespaceHelperTest extends AbstractTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         if (true === self::$built) {
             return;
         }

--- a/tests/Large/CodeGeneration/NamespaceHelperTest.php
+++ b/tests/Large/CodeGeneration/NamespaceHelperTest.php
@@ -72,7 +72,7 @@ class NamespaceHelperTest extends AbstractTest
 
     /**
      * @test
-     * @small
+     * @large
      */
     public function getFixtureFqnFromEntityFqn()
     {

--- a/tests/Large/CodeGeneration/UnusedRelationsRemoverTest.php
+++ b/tests/Large/CodeGeneration/UnusedRelationsRemoverTest.php
@@ -46,7 +46,7 @@ class UnusedRelationsRemoverTest extends AbstractTest
      */
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         $this->relationsGenerator = $this->getRelationsGenerator();
         $entityGenerator          = $this->getEntityGenerator();
         foreach (self::TEST_ENTITIES as $fqn) {

--- a/tests/Large/Entity/Embeddable/Traits/Financial/HasMoneyEmbeddableTraitLargeTest.php
+++ b/tests/Large/Entity/Embeddable/Traits/Financial/HasMoneyEmbeddableTraitLargeTest.php
@@ -24,7 +24,7 @@ class HasMoneyEmbeddableTraitLargeTest extends AbstractLargeTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         if (true === self::$built) {
             return;
         }

--- a/tests/Large/Entity/Embeddable/Traits/Geo/HasAddressEmbeddableTraitLargeTest.php
+++ b/tests/Large/Entity/Embeddable/Traits/Geo/HasAddressEmbeddableTraitLargeTest.php
@@ -19,7 +19,7 @@ class HasAddressEmbeddableTraitLargeTest extends AbstractLargeTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         if (false === self::$built) {
             $this->getEntityGenerator()->generateEntity(self::TEST_ENTITY);
             $this->getEntityEmbeddableSetter()

--- a/tests/Large/Entity/Embeddable/Traits/Identity/HasFullNameEmbeddableTraitLargeTest.php
+++ b/tests/Large/Entity/Embeddable/Traits/Identity/HasFullNameEmbeddableTraitLargeTest.php
@@ -19,7 +19,7 @@ class HasFullNameEmbeddableTraitLargeTest extends AbstractLargeTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         $this->getEntityGenerator()->generateEntity(self::TEST_ENTITY);
         $this->getEntityEmbeddableSetter()
              ->setEntityHasEmbeddable(self::TEST_ENTITY, HasFullNameEmbeddableTrait::class);

--- a/tests/Large/Entity/Factory/EntityFactoryTest.php
+++ b/tests/Large/Entity/Factory/EntityFactoryTest.php
@@ -27,7 +27,7 @@ class EntityFactoryTest extends AbstractTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         if (false === static::$built) {
             $this->buildOnce();
         }

--- a/tests/Large/Entity/Fields/Traits/AbstractFieldTraitLargeTest.php
+++ b/tests/Large/Entity/Fields/Traits/AbstractFieldTraitLargeTest.php
@@ -60,7 +60,7 @@ abstract class AbstractFieldTraitLargeTest extends AbstractLargeTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         $this->entitySuffix = substr(static::class, strrpos(static::class, '\\') + 1);
         $this->generateCode();
     }

--- a/tests/Large/Entity/Repositories/AbstractEntityRepositoryLargeTest.php
+++ b/tests/Large/Entity/Repositories/AbstractEntityRepositoryLargeTest.php
@@ -52,7 +52,7 @@ class AbstractEntityRepositoryLargeTest extends AbstractLargeTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         $this->generateCode();
         $this->setupCopiedWorkDirAndCreateDatabase();
         $this->generateAndSaveTestEntities();
@@ -171,7 +171,6 @@ class AbstractEntityRepositoryLargeTest extends AbstractLargeTest
     {
         foreach (MappingHelper::COMMON_TYPES as $key => $property) {
             $entity = $this->getEntityByKey($key);
-            ;
             $getter   = $this->getGetterForType($property);
             $criteria = [$property => $entity->$getter()];
             $actual   = $this->repository->findBy($criteria);
@@ -293,7 +292,6 @@ class AbstractEntityRepositoryLargeTest extends AbstractLargeTest
     {
         foreach (MappingHelper::COMMON_TYPES as $key => $property) {
             $entity = $this->getEntityByKey($key);
-            ;
             $getter   = $this->getGetterForType($property);
             $value    = $entity->$getter();
             $criteria = new Criteria();

--- a/tests/Large/Entity/Savers/AbstractEntitySpecificSaverTest.php
+++ b/tests/Large/Entity/Savers/AbstractEntitySpecificSaverTest.php
@@ -52,7 +52,7 @@ class AbstractEntitySpecificSaverTest extends AbstractLargeTest
      */
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         $fieldFqn = $this->getFieldGenerator()
                          ->generateField(
                              self::TEST_PROJECT_ROOT_NAMESPACE . '\\'

--- a/tests/Large/Entity/Savers/EntitySaverLargeTest.php
+++ b/tests/Large/Entity/Savers/EntitySaverLargeTest.php
@@ -25,7 +25,7 @@ class EntitySaverLargeTest extends AbstractLargeTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         $fieldGenerator = $this->getFieldGenerator();
         foreach (self::TEST_FIELDS as $fieldFqn) {
             $fieldGenerator->generateField($fieldFqn, MappingHelper::TYPE_STRING);

--- a/tests/Large/Entity/Testing/FixturesTest.php
+++ b/tests/Large/Entity/Testing/FixturesTest.php
@@ -44,7 +44,7 @@ class FixturesTest extends AbstractLargeTest
 
     public function setup(): void
     {
-        parent::setup();
+        parent::setUp();
         if (false === self::$built) {
             $this->getTestCodeGenerator()
                  ->copyTo(self::WORK_DIR, self::TEST_PROJECT_ROOT_NAMESPACE);

--- a/tests/Large/Entity/Testing/TestEntityGeneratorLargeTest.php
+++ b/tests/Large/Entity/Testing/TestEntityGeneratorLargeTest.php
@@ -31,7 +31,7 @@ class TestEntityGeneratorLargeTest extends AbstractLargeTest
 
     public function setup(): void
     {
-        parent::setup();
+        parent::setUp();
         if (false === self::$built) {
             $this->getTestCodeGenerator()
                  ->copyTo(self::WORK_DIR);

--- a/tests/Large/ProxiesTest.php
+++ b/tests/Large/ProxiesTest.php
@@ -35,7 +35,7 @@ class ProxiesTest extends AbstractLargeTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         if (false === self::$built) {
             $this->getTestCodeGenerator()
                  ->copyTo(self::WORK_DIR);

--- a/tests/Medium/Entity/Embeddable/Traits/Financial/HasMoneyEmbeddableTraitTest.php
+++ b/tests/Medium/Entity/Embeddable/Traits/Financial/HasMoneyEmbeddableTraitTest.php
@@ -19,7 +19,7 @@ class HasMoneyEmbeddableTraitTest extends AbstractTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         if (false === self::$built) {
             $this->getEntityGenerator()->generateEntity(self::TEST_ENTITY);
             $this->getEntityEmbeddableSetter()

--- a/tests/Medium/Entity/Embeddable/Traits/Geo/HasAddressEmbeddableTraitTest.php
+++ b/tests/Medium/Entity/Embeddable/Traits/Geo/HasAddressEmbeddableTraitTest.php
@@ -17,7 +17,7 @@ class HasAddressEmbeddableTraitTest extends AbstractTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         if (false === self::$built) {
             $this->getEntityGenerator()->generateEntity(self::TEST_ENTITY);
             $this->getEntityEmbeddableSetter()

--- a/tests/Medium/Entity/Embeddable/Traits/Identity/HasFullNameEmbeddableTraitTest.php
+++ b/tests/Medium/Entity/Embeddable/Traits/Identity/HasFullNameEmbeddableTraitTest.php
@@ -18,7 +18,7 @@ class HasFullNameEmbeddableTraitTest extends AbstractTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         if (false === self::$built) {
             $this->getEntityGenerator()->generateEntity(self::TEST_ENTITY);
             $this->getEntityEmbeddableSetter()

--- a/tests/Medium/Entity/Savers/EntitySaverFactoryTest.php
+++ b/tests/Medium/Entity/Savers/EntitySaverFactoryTest.php
@@ -34,7 +34,7 @@ class EntitySaverFactoryTest extends AbstractTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         $this->factory = new EntitySaverFactory(
             $this->getEntityManager(),
             $this->container->get(EntitySaver::class),

--- a/tests/Medium/Entity/Testing/EntityDebugDumperTest.php
+++ b/tests/Medium/Entity/Testing/EntityDebugDumperTest.php
@@ -38,7 +38,7 @@ class EntityDebugDumperTest extends AbstractTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         $this->getEntityGenerator()->generateEntity(self::TEST_ENTITY_FQN);
         $this->getFieldGenerator()->generateField(
             self::TEST_DECIMAL_FIELD,

--- a/tests/Medium/Entity/Testing/EntityGenerator/TestEntityGeneratorFactoryTest.php
+++ b/tests/Medium/Entity/Testing/EntityGenerator/TestEntityGeneratorFactoryTest.php
@@ -19,7 +19,7 @@ class TestEntityGeneratorFactoryTest extends AbstractTest
 
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         if (false === self::$built) {
             $this->getEntityGenerator()->generateEntity(self::TEST_ENTITY_FQN);
             self::$built = true;

--- a/tests/Medium/Entity/Validation/EntityValidatorTest.php
+++ b/tests/Medium/Entity/Validation/EntityValidatorTest.php
@@ -36,7 +36,7 @@ class EntityValidatorTest extends AbstractTest
      */
     public function setup()
     {
-        parent::setup();
+        parent::setUp();
         if (false === self::$built) {
             $this->getEntityGenerator()->generateEntity(self::TEST_ENTITY_SERVER);
             $this->getFieldSetter()->setEntityHasField(


### PR DESCRIPTION
Entity type hinting is inconsistent between `TemplateEntity` and `TemplateEntityInterface`

also on a very related note, the return types are inconsistent between various interfaces and the actual implementing Entity - this one is more subtle and sohuld be handled as a separate PR to avoid too many things going wrong at once