### PR TITLE
Update the notify method to use the currency code rather than amount

### DIFF
--- a/src/Entity/Embeddable/Objects/Financial/MoneyEmbeddable.php
+++ b/src/Entity/Embeddable/Objects/Financial/MoneyEmbeddable.php
@@ -80,7 +80,7 @@ class MoneyEmbeddable extends AbstractEmbeddableObject implements MoneyEmbeddabl
         $this->notifyEmbeddablePrefixedProperties(
             'currencyCode',
             $this->currencyCode,
-            $money->getAmount()
+            $currencyCode
         );
         $this->money        = $money;
         $this->amount       = $amount;


### PR DESCRIPTION
Currently the Money Embeddable is setting the money amount rather
than the currency code when updating an object. This fixes that