### PR TITLE
Allow the Fixtures Loader to be replaced with a new one

### DIFF
--- a/src/Entity/Testing/Fixtures/FixturesHelper.php
+++ b/src/Entity/Testing/Fixtures/FixturesHelper.php
@@ -165,6 +165,11 @@ class FixturesHelper
         $this->fixtureLoader->addFixture($fixture);
     }
 
+    public function clearFixtures(): void
+    {
+        $this->fixtureLoader = new Loader();
+    }
+
     public function run(): void
     {
         $cacheKey = $this->getCacheKey();


### PR DESCRIPTION
At the moment, once a fixture is added once it will get loaded every time
the run method is called. This is less than ideal when the class is
getting passed around a large test suite where different test want
different fixtures.

This adds in a new method that allows the current fixtureLoader to be
replaced with a new empty one.