### PR TITLE
Allow entities to share IDs

### DIFF
--- a/src/Entity/Factory/EntityFactory.php
+++ b/src/Entity/Factory/EntityFactory.php
@@ -140,11 +140,11 @@ class EntityFactory implements GenericFactoryInterface, EntityFactoryInterface
             $dto = $this->dtoFactory->createEmptyDtoFromEntityFqn($entityFqn);
         }
         $idString = (string)$dto->getId();
-        if (isset(self::$created[$idString])) {
-            return self::$created[$idString];
+        if (isset(self::$created[$entityFqn][$idString])) {
+            return self::$created[$entityFqn][$idString];
         }
         $entity                   = $this->getNewInstance($entityFqn, $dto->getId());
-        self::$created[$idString] = $entity;
+        self::$created[$entityFqn][$idString] = $entity;
 
         $this->updateDto($entity, $dto);
         if ($isRootEntity) {
@@ -470,12 +470,14 @@ class EntityFactory implements GenericFactoryInterface, EntityFactoryInterface
      */
     private function stopTransaction(): void
     {
-        foreach (self::$created as $entity) {
-            $transactionProperty = $entity::getDoctrineStaticMeta()
-                                          ->getReflectionClass()
-                                          ->getProperty(AlwaysValidInterface::CREATION_TRANSACTION_RUNNING_PROPERTY);
-            $transactionProperty->setAccessible(true);
-            $transactionProperty->setValue($entity, false);
+        foreach (self::$created as $entities) {
+            foreach ($entities as $entity) {
+                $transactionProperty = $entity::getDoctrineStaticMeta()
+                                              ->getReflectionClass()
+                                              ->getProperty(AlwaysValidInterface::CREATION_TRANSACTION_RUNNING_PROPERTY);
+                $transactionProperty->setAccessible(true);
+                $transactionProperty->setValue($entity, false);
+            }
         }
         //self::$created       = [];
         $this->dtosProcessed = [];

--- a/src/Entity/Factory/EntityFactory.php
+++ b/src/Entity/Factory/EntityFactory.php
@@ -25,7 +25,7 @@ class EntityFactory implements GenericFactoryInterface, EntityFactoryInterface
     /**
      * This array is used to track Entities that in the process of being created as part of a transaction
      *
-     * @var array|EntityInterface[]
+     * @var array
      */
     private static $created = [];
     /**

--- a/src/Entity/Factory/EntityFactory.php
+++ b/src/Entity/Factory/EntityFactory.php
@@ -472,9 +472,10 @@ class EntityFactory implements GenericFactoryInterface, EntityFactoryInterface
     {
         foreach (self::$created as $entities) {
             foreach ($entities as $entity) {
-                $transactionProperty = $entity::getDoctrineStaticMeta()
-                                              ->getReflectionClass()
-                                              ->getProperty(AlwaysValidInterface::CREATION_TRANSACTION_RUNNING_PROPERTY);
+                $transactionProperty =
+                    $entity::getDoctrineStaticMeta()
+                           ->getReflectionClass()
+                           ->getProperty(AlwaysValidInterface::CREATION_TRANSACTION_RUNNING_PROPERTY);
                 $transactionProperty->setAccessible(true);
                 $transactionProperty->setValue($entity, false);
             }

--- a/src/Entity/Factory/EntityFactory.php
+++ b/src/Entity/Factory/EntityFactory.php
@@ -166,7 +166,7 @@ class EntityFactory implements GenericFactoryInterface, EntityFactoryInterface
      */
     private function getNewInstance(string $entityFqn, $id): EntityInterface
     {
-        if (isset(self::$created[(string)$id])) {
+        if (isset(self::$created[$entityFqn][(string)$id])) {
             throw new \RuntimeException('Trying to get a new instance when one has already been created for this ID');
         }
         $reflection = $this->getDoctrineStaticMetaForEntityFqn($entityFqn)


### PR DESCRIPTION
At the moment the system is setup to enforce that every ID has to be
unique across all entities.

This will cause problems when we implement inheritance, or deterministic
UUIDs that may require different entities to have the same ID, or use
something other than UUIDs to identify entities.

This starts the process of ensuring that IDs are only unique within each
entity type