### PR TITLE
Allow entity have have a property with the same name

### DIFF
--- a/src/CodeGeneration/Generator/Field/ArchetypeFieldGenerator.php
+++ b/src/CodeGeneration/Generator/Field/ArchetypeFieldGenerator.php
@@ -220,15 +220,11 @@ class ArchetypeFieldGenerator
 
     private function getNewFqnSubNamespace(): string
     {
-        list(
-            $className,
-            ,
-            $subDirectories
-            ) = $this->namespaceHelper->parseFullyQualifiedName(
-                $this->fieldFqn,
-                'src',
-                $this->projectRootNamespace
-            );
+        [,,$subDirectories] = $this->namespaceHelper->parseFullyQualifiedName(
+            $this->fieldFqn,
+            'src',
+            $this->projectRootNamespace
+        );
         array_shift($subDirectories);
         $subNamespaceParts = [];
         foreach ($subDirectories as $subDirectory) {

--- a/src/CodeGeneration/Generator/Field/ArchetypeFieldGenerator.php
+++ b/src/CodeGeneration/Generator/Field/ArchetypeFieldGenerator.php
@@ -220,7 +220,7 @@ class ArchetypeFieldGenerator
 
     private function getNewFqnSubNamespace(): string
     {
-        [,,$subDirectories] = $this->namespaceHelper->parseFullyQualifiedName(
+        list(,,$subDirectories) = $this->namespaceHelper->parseFullyQualifiedName(
             $this->fieldFqn,
             'src',
             $this->projectRootNamespace

--- a/src/CodeGeneration/Generator/Field/ArchetypeFieldGenerator.php
+++ b/src/CodeGeneration/Generator/Field/ArchetypeFieldGenerator.php
@@ -232,9 +232,6 @@ class ArchetypeFieldGenerator
         array_shift($subDirectories);
         $subNamespaceParts = [];
         foreach ($subDirectories as $subDirectory) {
-            if ($subDirectory === $className) {
-                break;
-            }
             if ('Traits' === $subDirectory) {
                 $subDirectory = '\$1';
             }


### PR DESCRIPTION
At the moment this is possible when using the Mapping helper fields, but
is not possible when using Archetypes. I'm having a look to see if
removing the restriction causes problems