### PR TITLE
Allow non ordered, binary UUIDs

### DIFF
--- a/src/EntityManager/EntityManagerFactory.php
+++ b/src/EntityManager/EntityManagerFactory.php
@@ -17,6 +17,7 @@ use EdmondsCommerce\DoctrineStaticMeta\EntityManager\RetryConnection\ShouldConne
 use EdmondsCommerce\DoctrineStaticMeta\Exception\DoctrineStaticMetaException;
 use EdmondsCommerce\DoctrineStaticMeta\MappingHelper;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\Doctrine\UuidBinaryType;
 use Ramsey\Uuid\Doctrine\UuidType;
 
 /**
@@ -56,6 +57,10 @@ class EntityManagerFactory implements EntityManagerFactoryInterface
 
         if (!Type::hasType(MappingHelper::TYPE_NON_BINARY_UUID)) {
             Type::addType(MappingHelper::TYPE_NON_BINARY_UUID, UuidType::class);
+        }
+
+        if (!Type::hasType(MappingHelper::TYPE_NON_ORDERED_BINARY_UUID)) {
+            Type::addType(MappingHelper::TYPE_NON_ORDERED_BINARY_UUID, UuidBinaryType::class);
         }
     }
 

--- a/src/MappingHelper.php
+++ b/src/MappingHelper.php
@@ -10,6 +10,7 @@ use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\NamespaceHelper;
 use EdmondsCommerce\DoctrineStaticMeta\CodeGeneration\TypeHelper;
 use EdmondsCommerce\DoctrineStaticMeta\Schema\Database;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\Doctrine\UuidBinaryType;
 use Ramsey\Uuid\Doctrine\UuidType;
 
 /**
@@ -27,8 +28,9 @@ class MappingHelper
     /**
      * Primary Key types (beyond the common types)
      */
-    public const TYPE_UUID            = UuidBinaryOrderedTimeType::NAME;
-    public const TYPE_NON_BINARY_UUID = UuidType::NAME;
+    public const TYPE_UUID                    = UuidBinaryOrderedTimeType::NAME;
+    public const TYPE_NON_BINARY_UUID         = UuidType::NAME;
+    public const TYPE_NON_ORDERED_BINARY_UUID = UuidBinaryType::NAME;
 
     /**
      * Quick accessors for common types that are supported by methods in this helper


### PR DESCRIPTION
At the moment we are have to use either the binary ordered UUID field or
the non binary UUID field. The binary version requires you to use a UUID
v1, however sometimes you may wish to use a deterministic UUID (i.e. v3
or 5).

This adds the non ordered binary field to Mapping helper and registers
it with doctrine, to allow this to be used.