### PR TITLE
Provide an option for the Upserter to create entities without persisting

### DIFF
--- a/codeTemplates/src/Entity/Savers/TemplateEntityUpserter.php
+++ b/codeTemplates/src/Entity/Savers/TemplateEntityUpserter.php
@@ -150,7 +150,6 @@ class TemplateEntityUpserter
         $entity = $this->unitOfWorkHelper->getEntityFromUnitOfWorkUsingDto($dto);
         $entity->update($dto);
 
-
         return $entity;
     }
 }

--- a/codeTemplates/src/Entity/Savers/TemplateEntityUpserter.php
+++ b/codeTemplates/src/Entity/Savers/TemplateEntityUpserter.php
@@ -126,20 +126,21 @@ class TemplateEntityUpserter
      */
     public function persistUpsertDto(TemplateEntityDto $dto): TemplateEntityInterface
     {
-        if ($this->unitOfWorkHelper->hasRecordOfDto($dto) === false) {
-            $entity = $this->entityFactory->create($dto);
-            $this->saver->save($entity);
-
-            return $entity;
-        }
-        $entity = $this->unitOfWorkHelper->getEntityFromUnitOfWorkUsingDto($dto);
-        $entity->update($dto);
+        $entity = $this->convertUpsertDtoToEntity($dto);
         $this->saver->save($entity);
 
         return $entity;
     }
 
-    public function convertUpsertDto(TemplateEntityDto $dto): TemplateEntityInterface
+    /**
+     * This method will convert the DTO into an entity, but will not save it. This is useful if you want to bulk create
+     * or update entities
+     *
+     * @param TemplateEntityDto $dto
+     *
+     * @return TemplateEntityInterface
+     */
+    public function convertUpsertDtoToEntity(TemplateEntityDto $dto): TemplateEntityInterface
     {
         if ($this->unitOfWorkHelper->hasRecordOfDto($dto) === false) {
             $entity = $this->entityFactory->create($dto);

--- a/codeTemplates/src/Entity/Savers/TemplateEntityUpserter.php
+++ b/codeTemplates/src/Entity/Savers/TemplateEntityUpserter.php
@@ -138,4 +138,18 @@ class TemplateEntityUpserter
 
         return $entity;
     }
+
+    public function convertUpsertDto(TemplateEntityDto $dto): TemplateEntityInterface
+    {
+        if ($this->unitOfWorkHelper->hasRecordOfDto($dto) === false) {
+            $entity = $this->entityFactory->create($dto);
+
+            return $entity;
+        }
+        $entity = $this->unitOfWorkHelper->getEntityFromUnitOfWorkUsingDto($dto);
+        $entity->update($dto);
+
+
+        return $entity;
+    }
 }

--- a/tests/Small/CodeGeneration/Creation/Src/Entity/Savers/EntityUpserterCreatorTest.php
+++ b/tests/Small/CodeGeneration/Creation/Src/Entity/Savers/EntityUpserterCreatorTest.php
@@ -148,20 +148,33 @@ class TestEntityUpserter
      */
     public function persistUpsertDto(TestEntityDto $dto): TestEntityInterface
     {
+        $entity = $this->convertUpsertDtoToEntity($dto);
+        $this->saver->save($entity);
+
+        return $entity;
+    }
+
+    /**
+     * This method will convert the DTO into an entity, but will not save it. This is useful if you want to bulk create
+     * or update entities
+     *
+     * @param TestEntityDto $dto
+     *
+     * @return TestEntityInterface
+     */
+    public function convertUpsertDtoToEntity(TestEntityDto $dto): TestEntityInterface
+    {
         if ($this->unitOfWorkHelper->hasRecordOfDto($dto) === false) {
             $entity = $this->entityFactory->create($dto);
-            $this->saver->save($entity);
 
             return $entity;
         }
         $entity = $this->unitOfWorkHelper->getEntityFromUnitOfWorkUsingDto($dto);
         $entity->update($dto);
-        $this->saver->save($entity);
 
         return $entity;
     }
 }
-
 PHP;
 
     public const NESTED_UPSERTER = <<<'PHP'
@@ -293,20 +306,33 @@ class TestEntityUpserter
      */
     public function persistUpsertDto(TestEntityDto $dto): TestEntityInterface
     {
+        $entity = $this->convertUpsertDtoToEntity($dto);
+        $this->saver->save($entity);
+
+        return $entity;
+    }
+
+    /**
+     * This method will convert the DTO into an entity, but will not save it. This is useful if you want to bulk create
+     * or update entities
+     *
+     * @param TestEntityDto $dto
+     *
+     * @return TestEntityInterface
+     */
+    public function convertUpsertDtoToEntity(TestEntityDto $dto): TestEntityInterface
+    {
         if ($this->unitOfWorkHelper->hasRecordOfDto($dto) === false) {
             $entity = $this->entityFactory->create($dto);
-            $this->saver->save($entity);
 
             return $entity;
         }
         $entity = $this->unitOfWorkHelper->getEntityFromUnitOfWorkUsingDto($dto);
         $entity->update($dto);
-        $this->saver->save($entity);
 
         return $entity;
     }
 }
-
 PHP;
 
 


### PR DESCRIPTION
When bulk creating / updating entities we don't want to save them one by
one, but do this in bulk. This allows the upserter to do that