### PR TITLE
Added mysql error message on drop operation

### DIFF
--- a/src/Schema/Database.php
+++ b/src/Schema/Database.php
@@ -64,9 +64,11 @@ class Database
         $link = $this->connect();
         $sql  = "DROP DATABASE IF EXISTS `{$this->config->get(ConfigInterface::PARAM_DB_NAME)}`";
         if (true !== mysqli_query($link, $sql)) {
+            $mysqlError = mysqli_errno($link). ': '.mysqli_error($link);
             throw new DoctrineStaticMetaException(
                 'Failed to drop the database '
                 . $this->config->get(ConfigInterface::PARAM_DB_NAME)
+                . ' Mysql Error - '.$mysqlError
             );
         }
 


### PR DESCRIPTION
When the drop call fails, there is no useful error message.
This will tell you what the problem actually is.