### PR TITLE
Prevent valid constrain traversing by default

### DIFF
--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasRequiredTemplateEntitiesAbstract.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasRequiredTemplateEntitiesAbstract.php
@@ -38,6 +38,8 @@ trait HasRequiredTemplateEntitiesAbstract
     public static function validatorMetaForPropertyTemplateEntities(
         ValidatorClassMetaData $metadata
     ): void {
+        $validConstraint = new Valid();
+        $validConstraint->traverse = false;
         $metadata->addPropertyConstraint(
             HasRequiredTemplateEntitiesInterface::PROPERTY_NAME_TEMPLATE_ENTITIES,
             new Count(['min' => 1])
@@ -48,7 +50,7 @@ trait HasRequiredTemplateEntitiesAbstract
         );
         $metadata->addPropertyConstraint(
             HasRequiredTemplateEntitiesInterface::PROPERTY_NAME_TEMPLATE_ENTITIES,
-            new Valid()
+            $validConstraint
         );
     }
 

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasRequiredTemplateEntitiesAbstract.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasRequiredTemplateEntitiesAbstract.php
@@ -38,8 +38,6 @@ trait HasRequiredTemplateEntitiesAbstract
     public static function validatorMetaForPropertyTemplateEntities(
         ValidatorClassMetaData $metadata
     ): void {
-        $validConstraint = new Valid();
-        $validConstraint->traverse = false;
         $metadata->addPropertyConstraint(
             HasRequiredTemplateEntitiesInterface::PROPERTY_NAME_TEMPLATE_ENTITIES,
             new Count(['min' => 1])
@@ -47,10 +45,6 @@ trait HasRequiredTemplateEntitiesAbstract
         $metadata->addPropertyConstraint(
             HasRequiredTemplateEntitiesInterface::PROPERTY_NAME_TEMPLATE_ENTITIES,
             new NotBlank()
-        );
-        $metadata->addPropertyConstraint(
-            HasRequiredTemplateEntitiesInterface::PROPERTY_NAME_TEMPLATE_ENTITIES,
-            $validConstraint
         );
     }
 

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasRequiredTemplateEntityAbstract.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasRequiredTemplateEntityAbstract.php
@@ -40,13 +40,15 @@ trait HasRequiredTemplateEntityAbstract
     public static function validatorMetaForPropertyTemplateEntity(
         ValidatorClassMetaData $metadata
     ): void {
+        $validConstraint = new Valid();
+        $validConstraint->traverse = false;
         $metadata->addPropertyConstraint(
             HasRequiredTemplateEntityInterface::PROPERTY_NAME_TEMPLATE_ENTITY,
             new NotBlank()
         );
         $metadata->addPropertyConstraint(
             HasRequiredTemplateEntityInterface::PROPERTY_NAME_TEMPLATE_ENTITY,
-            new Valid()
+            $validConstraint
         );
     }
 

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntitiesAbstract.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntitiesAbstract.php
@@ -27,6 +27,11 @@ trait HasTemplateEntitiesAbstract
     private $templateEntities;
 
     /**
+     * This method sets the validation for this field.
+     * You should add in as many relevant property constraints as you see fit.
+     *
+     * Remove the PHPMD suppressed warning once you start setting constraints
+     * 
      * @param ValidatorClassMetaData $metadata
      *
      * @throws \Symfony\Component\Validator\Exception\MissingOptionsException

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntitiesAbstract.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntitiesAbstract.php
@@ -32,16 +32,18 @@ trait HasTemplateEntitiesAbstract
      * @throws \Symfony\Component\Validator\Exception\MissingOptionsException
      * @throws \Symfony\Component\Validator\Exception\InvalidOptionsException
      * @throws \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public static function validatorMetaForPropertyTemplateEntities(
         ValidatorClassMetaData $metadata
     ): void {
-        $validConstraint = new Valid();
-        $validConstraint->traverse = false;
-        $metadata->addPropertyConstraint(
-            HasTemplateEntitiesInterface::PROPERTY_NAME_TEMPLATE_ENTITIES,
-            $validConstraint
-        );
+//        $validConstraint = new Valid();
+//        $validConstraint->traverse = false;
+//        $metadata->addPropertyConstraint(
+//            HasTemplateEntitiesInterface::PROPERTY_NAME_TEMPLATE_ENTITIES,
+//            $validConstraint
+//        );
     }
 
     /**

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntitiesAbstract.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntitiesAbstract.php
@@ -36,9 +36,11 @@ trait HasTemplateEntitiesAbstract
     public static function validatorMetaForPropertyTemplateEntities(
         ValidatorClassMetaData $metadata
     ): void {
+        $validConstraint = new Valid();
+        $validConstraint->traverse = false;
         $metadata->addPropertyConstraint(
             HasTemplateEntitiesInterface::PROPERTY_NAME_TEMPLATE_ENTITIES,
-            new Valid()
+            $validConstraint
         );
     }
 

--- a/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntityAbstract.php
+++ b/codeTemplates/src/Entity/Relations/TemplateEntity/Traits/HasTemplateEntityAbstract.php
@@ -44,9 +44,11 @@ trait HasTemplateEntityAbstract
     public static function validatorMetaForPropertyTemplateEntity(
         ValidatorClassMetaData $metadata
     ): void {
+        $validConstraint = new Valid();
+        $validConstraint->traverse = false;
         $metadata->addPropertyConstraint(
             HasTemplateEntityInterface::PROPERTY_NAME_TEMPLATE_ENTITY,
-            new Valid()
+            $validConstraint
         );
     }
 

--- a/src/Entity/Validation/Initialiser.php
+++ b/src/Entity/Validation/Initialiser.php
@@ -88,10 +88,6 @@ class Initialiser implements ObjectInitializerInterface
                 $this->initialiseObject($got);
                 continue;
             }
-            if ($got instanceof PersistentCollection) {
-                $this->initialiseObject($got);
-                continue;
-            }
         }
     }
 }


### PR DESCRIPTION
By default the Valid constraint will call itself on every object in a
collection. This means that each item has to be loaded and itself
validated, which if it the items also contain collections this can
become expensive very quickly when working with large amounts of data.

This changes the default behaviour to not load these up, allowing this
to be overwritten if needed