### PR TITLE
adding a new mapCriteriaSetUuidsToStrings to the abstract entity repo…

### DIFF
--- a/src/CodeGeneration/PostProcessor/FileOverrider.php
+++ b/src/CodeGeneration/PostProcessor/FileOverrider.php
@@ -100,7 +100,7 @@ class FileOverrider
     {
         $fileDirectory       = $this->getOverrideDirectoryForFile($relativePathToFileInProject);
         $fileNameNoExtension = $this->getFileNameNoExtensionForPathInProject($relativePathToFileInProject);
-        $filesInDirectory    = glob("$fileDirectory/$fileNameNoExtension*");
+        $filesInDirectory    = glob("$fileDirectory/$fileNameNoExtension*" . self::OVERRIDE_EXTENSION);
         if ([] === $filesInDirectory) {
             return null;
         }

--- a/src/CodeGeneration/PostProcessor/FileOverrider.php
+++ b/src/CodeGeneration/PostProcessor/FileOverrider.php
@@ -15,6 +15,7 @@ class FileOverrider
 
     private const EXTENSION_LENGTH_NO_HASH_IN_PROJECT     = 4;
     private const EXTENSION_LENGTH_WITH_HASH_IN_OVERRIDES = 46;
+    private const OVERRIDE_EXTENSION                      = 'override';
 
     /**
      * @var string
@@ -207,6 +208,14 @@ class FileOverrider
                  * @var \SplFileInfo $fileInfo
                  */
                 if ($fileInfo->isFile()) {
+                    if (
+                        self::OVERRIDE_EXTENSION !== substr(
+                            $fileInfo->getFilename(),
+                            -strlen(self::OVERRIDE_EXTENSION)
+                        )
+                    ) {
+                        continue;
+                    }
                     yield $fileInfo->getPathname();
                 }
             }

--- a/src/Entity/Repositories/AbstractEntityRepository.php
+++ b/src/Entity/Repositories/AbstractEntityRepository.php
@@ -219,16 +219,18 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
         return $this->initialiseEntity($result);
     }
 
-    public function mapCriteriaSetUuidsToStrings(array &$criteria): void
+    public function mapCriteriaSetUuidsToStrings(array $criteria): array
     {
-        foreach ($criteria as $property => &$value) {
+        foreach ($criteria as $property => $value) {
             if ($value instanceof EntityInterface) {
-                $value = $value->getId();
+                $criteria[$property] = $value->getId();
             }
             if ($value instanceof UuidInterface) {
-                $value = $value->toString();
+                $criteria[$property] = $value->toString();
             }
         }
+
+        return $criteria;
     }
 
     /**
@@ -239,8 +241,8 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
      */
     public function findOneBy(array $criteria, ?array $orderBy = null)
     {
-        $this->mapCriteriaSetUuidsToStrings($criteria);
-        $entity = $this->entityRepository->findOneBy($criteria, $orderBy);
+        $criteria = $this->mapCriteriaSetUuidsToStrings($criteria);
+        $entity   = $this->entityRepository->findOneBy($criteria, $orderBy);
         if (null === $entity) {
             return null;
         }
@@ -289,7 +291,8 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
 
     public function count(array $criteria = []): int
     {
-        $this->mapCriteriaSetUuidsToStrings($criteria);
+        $criteria = $this->mapCriteriaSetUuidsToStrings($criteria);
+
         return $this->entityRepository->count($criteria);
     }
 
@@ -298,13 +301,13 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
      */
     public function findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null): array
     {
-        $this->mapCriteriaSetUuidsToStrings($criteria);
+        $criteria = $this->mapCriteriaSetUuidsToStrings($criteria);
+
         return $this->initialiseEntities($this->entityRepository->findBy($criteria, $orderBy, $limit, $offset));
     }
 
     public function matching(Criteria $criteria): LazyCriteriaCollection
     {
-        $this->mapCriteriaSetUuidsToStrings($criteria);
         $collection = $this->entityRepository->matching($criteria);
         if ($collection instanceof LazyCriteriaCollection) {
             return $this->initialiseEntities($collection);

--- a/src/Entity/Savers/BulkEntityUpdater.php
+++ b/src/Entity/Savers/BulkEntityUpdater.php
@@ -202,7 +202,7 @@ class BulkEntityUpdater extends AbstractBulkProcess
             return "'$uuidString'";
         }
 
-        return UuidFunctionPolyfill::UUID_TO_BIN . "('$uuidString')";
+        return UuidFunctionPolyfill::UUID_TO_BIN . "('$uuidString', true)";
     }
 
     private function runQuery(): void

--- a/src/Entity/Savers/BulkSimpleEntityCreator.php
+++ b/src/Entity/Savers/BulkSimpleEntityCreator.php
@@ -227,8 +227,7 @@ class BulkSimpleEntityCreator extends AbstractBulkProcess
     {
         if ($this->isBinaryUuid) {
             $uuidString = (string)$uuid;
-
-            return "UUID_TO_BIN('$uuidString')";
+            return "UUID_TO_BIN('$uuidString', true)";
         }
 
         throw new \RuntimeException('This is not currently suppported - should be easy enough though');

--- a/src/Schema/UuidFunctionPolyfill.php
+++ b/src/Schema/UuidFunctionPolyfill.php
@@ -11,6 +11,10 @@ use Doctrine\ORM\EntityManagerInterface;
  * This class handles ensuring that we have functions for converting to and from binary UUID formats in MySQL
  *
  * In MySQL8, these functions come built in, for below this version though we need to make our own
+ *
+ * NOTE - the native mysql 8 functions take a second parameter of true to create ordered UUIDs. The polyfill will
+ * always create ordered UUIDs
+ *
  */
 class UuidFunctionPolyfill
 {
@@ -68,33 +72,61 @@ class UuidFunctionPolyfill
     public function createProcedureUuidToBin(): void
     {
         $this->conn->query('
-            CREATE FUNCTION ' . self::UUID_TO_BIN . '(_uuid BINARY(36))
-                RETURNS BINARY(16)
-                LANGUAGE SQL  DETERMINISTIC  CONTAINS SQL  SQL SECURITY INVOKER
-            RETURN
-                UNHEX(CONCAT(
-                    SUBSTR(_uuid, 15, 4),
-                    SUBSTR(_uuid, 10, 4),
-                    SUBSTR(_uuid,  1, 8),
-                    SUBSTR(_uuid, 20, 4),
-                    SUBSTR(_uuid, 25) ));
+CREATE FUNCTION ' . self::UUID_TO_BIN . '(_uuid BINARY(36), _ordered BOOL)
+	RETURNS BINARY(16)
+	LANGUAGE SQL  DETERMINISTIC  CONTAINS SQL  SQL SECURITY INVOKER
+	BEGIN            
+		IF _ordered
+		THEN
+			RETURN UNHEX(CONCAT(
+		        SUBSTR(_uuid, 15, 4),
+		        SUBSTR(_uuid, 10, 4),
+		        SUBSTR(_uuid,  1, 8),
+		        SUBSTR(_uuid, 20, 4),
+		        SUBSTR(_uuid, 25)));
+		ELSE
+			RETURN UNHEX(CONCAT(
+		    	LEFT(_uuid, 8), 
+		    	MID(_uuid, 10, 4), 
+		    	MID(_uuid, 15, 4), 
+		    	MID(_uuid, 20, 4), 
+		    	RIGHT(_uuid, 12)));         
+		END IF;
+	END;
         ');
     }
 
     public function createProcedureBinToUuid(): void
     {
-        $this->conn->query('
-        CREATE FUNCTION ' . self::BIN_TO_UUID . "(_bin BINARY(16))
-            RETURNS BINARY(36)
-            LANGUAGE SQL  DETERMINISTIC  CONTAINS SQL  SQL SECURITY INVOKER
-        RETURN
-            LCASE(CONCAT_WS('-',
-                HEX(SUBSTR(_bin,  5, 4)),
-                HEX(SUBSTR(_bin,  3, 2)),
-                HEX(SUBSTR(_bin,  1, 2)),
-                HEX(SUBSTR(_bin,  9, 2)),
-                HEX(SUBSTR(_bin, 11))
-                     ));
+        $this->conn->query("
+CREATE FUNCTION ' . self::BIN_TO_UUID . '(_bin BINARY(16), _ordered BOOL)
+	RETURNS BINARY(36)
+        LANGUAGE SQL  DETERMINISTIC  CONTAINS SQL  SQL SECURITY INVOKER
+    BEGIN
+		DECLARE HEX CHAR(32);
+		SET HEX = HEX(_bin);
+		IF _ordered
+		THEN
+		    RETURN
+		        LCASE(CONCAT_WS('-',
+	                HEX(SUBSTR(_bin,  5, 4)),
+	                HEX(SUBSTR(_bin,  3, 2)),
+	                HEX(SUBSTR(_bin,  1, 2)),
+	                HEX(SUBSTR(_bin,  9, 2)),
+	                HEX(SUBSTR(_bin, 11))
+		        ));
+	   	ELSE       	
+			RETURN 
+				LOWER(CONCAT_WS('-',
+					LEFT(HEX, 8), 
+					MID(HEX, 9,4),
+					MID(HEX, 13,4),
+					MID(HEX, 17,4),
+					RIGHT(HEX, 12)
+				));
+		   
+	   	END IF;
+	END;
         ");
     }
 }

--- a/src/Schema/UuidFunctionPolyfill.php
+++ b/src/Schema/UuidFunctionPolyfill.php
@@ -99,7 +99,7 @@ CREATE FUNCTION ' . self::UUID_TO_BIN . '(_uuid BINARY(36), _ordered BOOL)
     public function createProcedureBinToUuid(): void
     {
         $this->conn->query("
-CREATE FUNCTION ' . self::BIN_TO_UUID . '(_bin BINARY(16), _ordered BOOL)
+CREATE FUNCTION " . self::BIN_TO_UUID . "(_bin BINARY(16), _ordered BOOL)
 	RETURNS BINARY(36)
         LANGUAGE SQL  DETERMINISTIC  CONTAINS SQL  SQL SECURITY INVOKER
     BEGIN


### PR DESCRIPTION
…sitory

The repository methods that take criterias will fail if passed the entity directly

This change ensures that entity IDs are retrieved and converted to strings, this then lets everything work as expected